### PR TITLE
add new oc-chef-pedant options to rspec setup

### DIFF
--- a/oc-chef-pedant
+++ b/oc-chef-pedant
@@ -7,9 +7,10 @@ require 'pedant'
 require 'pedant/opensource/platform'
 require 'pedant/multitenant'
 require 'pedant/organization'
+require 'pedant/oc_chef_command_line'
 
 Pedant.config.platform_class = Pedant::MultiTenantPlatform
-Pedant.setup(ARGV)
+Pedant.setup(ARGV, ["core_options", "api_options", "oc_chef_options"])
 puts Pedant::UI.new.info_banner
 
 exit RSpec::Core::Runner.run(Pedant.config.rspec_args)


### PR DESCRIPTION
Incorporate the new CommandLine:oc_chef_commands options into startup. 

Goes with this [https://github.com/opscode/oc-chef-pedant-core/pull/8
