### PR TITLE
authz_id is now part of the response from the principals endpoint.

### DIFF
--- a/spec/api/principal_spec.rb
+++ b/spec/api/principal_spec.rb
@@ -41,13 +41,15 @@ describe "Principals API Endpoint", :principals do
     {
       "name" => principal_client_name,
       "type" => "client",
-      "public_key" => /^-----BEGIN CERTIFICATE-----/
+      "public_key" => /^-----BEGIN CERTIFICATE-----/,
+      "authz_id" => /.+/
     } }
   let(:user_body) {
     {
       "name" => principal_user_name,
       "type" => "user",
-      "public_key" => /^-----BEGIN CERTIFICATE-----/
+      "public_key" => /^-----BEGIN CERTIFICATE-----/,
+      "authz_id" => /.+/
     } }
 
   describe 'access control' do


### PR DESCRIPTION
With corresponding chef_wm change https://github.com/opscode/chef_wm/pull/44.
