### PR TITLE
Pedant for OHC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source :rubygems
 gemspec
 
 # Specify a Github repo for this, since it isn't in Rubygems yet
-gem 'chef-pedant', :git => "git@github.com:opscode/chef-pedant.git"
+gem 'chef-pedant', :git => "git@github.com:opscode/chef-pedant.git", :branch => "sd/ohc-pedant"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: git@github.com:opscode/chef-pedant.git
-  revision: 04037a59ffa71479480b14a5d23f7e7d110fe1e1
+  revision: 402c8379eb3b398731b133258f43128c684fc1c9
+  branch: sd/ohc-pedant
   specs:
-    chef-pedant (0.0.11)
+    chef-pedant (1.0.4)
       activesupport (~> 3.2.8)
-      chef (~> 10.12.0)
       erubis (~> 2.7.0)
       mixlib-authentication (~> 1.3.0)
       mixlib-config (~> 1.1.2)
@@ -24,60 +24,21 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.11)
+    activesupport (3.2.12)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    builder (3.1.4)
-    bunny (0.8.0)
-    chef (10.12.0)
-      bunny (>= 0.6.0)
-      erubis
-      highline (>= 1.6.9)
-      json (>= 1.4.4, <= 1.6.1)
-      mixlib-authentication (>= 1.1.0)
-      mixlib-cli (>= 1.1.0)
-      mixlib-config (>= 1.1.2)
-      mixlib-log (>= 1.3.0)
-      mixlib-shellout
-      moneta
-      net-ssh (~> 2.2.2)
-      net-ssh-multi (~> 1.1.0)
-      ohai (>= 0.6.0)
-      rest-client (>= 1.0.4, < 1.7.0)
-      treetop (~> 1.4.9)
-      uuidtools
-      yajl-ruby (~> 1.1)
+    builder (3.2.0)
     diff-lcs (1.1.3)
     erubis (2.7.0)
-    highline (1.6.15)
-    i18n (0.6.1)
-    ipaddress (0.8.0)
-    json (1.6.1)
-    mime-types (1.19)
+    i18n (0.6.2)
+    mime-types (1.21)
     mixlib-authentication (1.3.0)
       mixlib-log
-    mixlib-cli (1.3.0)
     mixlib-config (1.1.2)
     mixlib-log (1.4.1)
     mixlib-shellout (1.1.0)
-    moneta (0.7.6)
-    multi_json (1.5.0)
+    multi_json (1.6.1)
     net-http-spy (0.2.1)
-    net-ssh (2.2.2)
-    net-ssh-gateway (1.1.0)
-      net-ssh (>= 1.99.1)
-    net-ssh-multi (1.1)
-      net-ssh (>= 2.1.4)
-      net-ssh-gateway (>= 0.99.0)
-    ohai (6.16.0)
-      ipaddress
-      mixlib-cli
-      mixlib-config
-      mixlib-log
-      mixlib-shellout
-      systemu
-      yajl-ruby
-    polyglot (0.3.3)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rspec (2.11.0)
@@ -90,16 +51,10 @@ GEM
     rspec-mocks (2.11.3)
     rspec-rerun (0.1.1)
       rspec (>= 2.11.0)
-    rspec_junit_formatter (0.1.5)
+    rspec_junit_formatter (0.1.6)
       builder
       rspec (~> 2.0)
       rspec-core (!= 2.12.0)
-    systemu (2.5.2)
-    treetop (1.4.12)
-      polyglot
-      polyglot (>= 0.3.1)
-    uuidtools (2.1.3)
-    yajl-ruby (1.1.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
This update bumps the version of chef-pedant to contain some fixes that are specific to OHC.

The Gemfile references the changes in the following pull request: https://github.com/opscode/chef-pedant/pull/38

It will need to be updated as soon as that PR is merged.
### Note

It appears that the recent builds of oc-chef-pedant and OPC are only running one test :panda_face:. The root cause of this issue should be addressed before more merges are made to the *-pedant projects. See CI tests [here](http://andra.ci.opscode.us/job/private-chef-test/14/build_os=ubuntu-10.04,machine_architecture=x86_64,project=private-chef,role=tester/console)
