### PR TITLE
Upgrade to webmachine 1.10.1 (and be compatible w/ Erlang R16)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org/'
 gemspec
 
 # Specify a Github repo for this, since it isn't in Rubygems yet
-gem 'chef-pedant', '1.0.5', :git => "git://github.com/opscode/chef-pedant.git", :tag => '1.0.5'
+gem 'chef-pedant', '1.0.5', :git => "git://github.com/opscode/chef-pedant.git", :branch => 'sf/R16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/opscode/chef-pedant.git
-  revision: 4dd7f9d787f6a7c936ae617dd2ac9d71c5a69239
-  tag: 1.0.5
+  revision: 30dbeec981994812f3581e148a319d75dc139ad7
+  branch: sf/R16
   specs:
     chef-pedant (1.0.5)
       activesupport (~> 3.2.8)
@@ -18,26 +18,26 @@ GIT
 PATH
   remote: .
   specs:
-    oc-chef-pedant (0.0.10)
+    oc-chef-pedant (1.0.3)
       chef-pedant (>= 0.0.10)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.12)
-      i18n (~> 0.6)
+    activesupport (3.2.13)
+      i18n (= 0.6.1)
       multi_json (~> 1.0)
     builder (3.2.0)
     diff-lcs (1.1.3)
     erubis (2.7.0)
-    i18n (0.6.2)
-    mime-types (1.21)
+    i18n (0.6.1)
+    mime-types (1.22)
     mixlib-authentication (1.3.0)
       mixlib-log
     mixlib-config (1.1.2)
-    mixlib-log (1.4.1)
+    mixlib-log (1.6.0)
     mixlib-shellout (1.1.0)
-    multi_json (1.6.1)
+    multi_json (1.7.2)
     net-http-spy (0.2.1)
     rest-client (1.6.7)
       mime-types (>= 1.16)


### PR DESCRIPTION
This multi-repo PR upgrades the webmachine (and bundled mochiweb)
version to 1.10.1. Among other fixes, the new versions of webmachine
and mochiweb no longer use parameterized modules, a feature which has
been removed from Erlang >= R16.

While, I've done some testing with R16B and things look good (and
despite the branch name) these patches upgrade wm and include a few
other compat fixes for R16, but erlang is left at R15B03 and things
work fine there too.

Note that the PR in opscode-omnibus is for testing only and will not
be merged.
