### PR TITLE
Fix for environment delete test -- was using incorrect requestor

### DIFF
--- a/spec/api/environments/delete_spec.rb
+++ b/spec/api/environments/delete_spec.rb
@@ -78,6 +78,7 @@ describe "Environments API Endpoint", :environments do
 
         context 'with a user with all permissions EXCEPT delete' do
           let(:expected_response) { forbidden_response }
+          let(:requestor) { normal_user }
 
           before(:each) do
             restrict_permissions_to("/environments/#{new_environment_name}",


### PR DESCRIPTION
Fix for broken test -- that accidentally found authz/bifröst difference, so there's that.  But probably should test the thing we actually want to test here.
