### PR TITLE
Use nobody user and pedant_admin user from config file

### DIFF
--- a/lib/pedant/multitenant/platform.rb
+++ b/lib/pedant/multitenant/platform.rb
@@ -295,8 +295,8 @@ module Pedant
         create_org(name)
       else
         key = org[:validator_key]
-        Pedant::Organization.new(name, key)
         puts "Using pre-created org. Skipping org creation validation tests."
+        Pedant::Organization.new(name, key)
       end
     end
 

--- a/spec/api/account/account_acl_spec.rb
+++ b/spec/api/account/account_acl_spec.rb
@@ -753,7 +753,7 @@ describe "ACL API", :acl do
         # default ACLs are different on almost every different types -- so these are
         # the defaults of defaults, which are overridden below for the different
         # types:
-        let(:actors) { ["pivotal", "pedant_admin_user"] }
+        let(:actors) { ["pivotal", platform.admin_user.name] }
         let(:groups) { ["admins"] }
         let(:read_groups) { groups }
         let(:update_groups) { groups }
@@ -790,7 +790,7 @@ describe "ACL API", :acl do
               "id" => new_object,
               "containerpath" => "/"
             }}
-          let(:actors) { ["pedant_admin_user"] }
+          let(:actors) { [platform.admin_user.name] }
           let(:groups) { [] }
           let(:grant_groups) { [] }
         when "data"

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -280,7 +280,7 @@ describe "users", :users do
           # There are other users, but these are ours, so they should always be
           # somewhere in the userspace soup.
           "pivotal" => "#{request_url}/pivotal",
-          "pedant-nobody" => "#{request_url}/pedant-nobody",
+          platform.bad_user.name => "#{request_url}/#{platform.bad_user.name}",
           platform.admin_user.name => "#{request_url}/#{platform.admin_user.name}",
           platform.non_admin_user.name => "#{request_url}/#{platform.non_admin_user.name}"
         }
@@ -373,7 +373,7 @@ describe "users", :users do
           # There are other users, but these are ours, so they should always be
           # somewhere in the userspace soup:
           "pivotal" => "#{request_url}/pivotal",
-          "pedant-nobody" => "#{request_url}/pedant-nobody",
+          platform.bad_user.name => "#{request_url}/#{platform.bad_user.name}",
           platform.admin_user.name => "#{request_url}/#{platform.admin_user.name}",
           platform.non_admin_user.name => "#{request_url}/#{platform.non_admin_user.name}",
           # As should our test user:


### PR DESCRIPTION
Use nobody user and pedant_admin user from config file instead of hardcoded name. This fixes tests against hosted chef.

@sdelano @tylercloke 
