### PR TITLE
initial pass: users endpoint in oc_erchef

### DIFF
--- a/oc-chef-pedant.gemspec
+++ b/oc-chef-pedant.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
   s.name          = 'oc-chef-pedant'
-  s.version       = '1.0.29'
-  s.date          = '2014-05-05'
-  s.summary       = "Opscode Private Chef API Testing Framework"
-  s.authors       = ["Opscode Software Engineering"]
-  s.email         = 'dev@opscode.com'
+  s.version       = '1.0.30'
+  s.date          = '2014-05-07'
+  s.summary       = "Enterprise Chef API Testing Framework"
+  s.authors       = ["Chef Software Engineering"]
+  s.email         = 'dev@getchef.com'
   s.require_paths = ['lib', 'spec']
   s.files         = Dir['lib/**/*.rb'] + Dir['spec/**/*_spec.rb']
-  s.homepage      = 'http://opscode.com'
+  s.homepage      = 'http://getchef.com'
 
   s.bindir        = 'bin'
   s.executables   = ['oc-chef-pedant']

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -1391,8 +1391,7 @@ EOF
             it "updates the user to the new name and provides a new uri" do
               put(request_url, platform.superuser,
                 :payload => request_body).should look_like({
-                  :status => 201, # Some debate re proper response 201/200, but
-                                  # webmachine says if a Location header is present, it's 201
+                  :status => 201,
                   :body_exact => { "uri" => new_request_url },
                   :headers => [ "Location" => new_request_url ]
                 })
@@ -1516,7 +1515,6 @@ EOF
                 :payload => request_body).should look_like({
                   :status => 409
                 })
-              # TODO is this really part of a valid PUT test?
               get(request_url, platform.superuser).should look_like({
                   :status => 200,
                   :body_exact => unmodified_user


### PR DESCRIPTION
- includes users endpoint support in erchef
- support in underyling components for oc_chef_wm requests
  that do not have a valid org, without stubbing out org.
- make oc_erchef aware of global containers in couch
- nginx routing for endpoints

/ping @opscode/server-team

Note that I'm leaning towards maintaining this as a feature branch
pending completion of other works in progress.
