### PR TITLE
Added /system_recovery endpoint and LDAP customization to /authenticate_user.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: git://github.com/opscode/chef-pedant.git
-  revision: 10b90e16adccbbd5ecf70b67acfcce48d454df92
-  tag: 1.0.27
+  revision: 749bf900dd85e8d82c0bf7cd7d0415945b93cdc3
+  tag: 1.0.29
   specs:
-    chef-pedant (1.0.27)
+    chef-pedant (1.0.29)
       activesupport (~> 3.2.8)
       erubis (~> 2.7.0)
       mixlib-authentication (~> 1.3.0)
-      mixlib-config (~> 1.1.2)
-      mixlib-shellout (~> 1.1.0)
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 1.1)
       net-http-spy (~> 0.2.1)
       rest-client (= 1.7.0.alpha)
-      rspec (~> 2.11.0)
+      rspec (~> 2.11)
       rspec-rerun (= 0.1.1)
       rspec_junit_formatter (~> 0.1.1)
 
@@ -27,39 +27,39 @@ GIT
 PATH
   remote: .
   specs:
-    oc-chef-pedant (1.0.29)
+    oc-chef-pedant (1.0.36)
       chef-pedant (>= 1.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.17)
+    activesupport (3.2.18)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     builder (3.2.2)
-    diff-lcs (1.1.3)
+    diff-lcs (1.2.5)
     erubis (2.7.0)
     i18n (0.6.9)
     json (1.8.1)
-    mime-types (2.2)
+    mime-types (2.3)
     mixlib-authentication (1.3.0)
       mixlib-log
-    mixlib-config (1.1.2)
+    mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.1.0)
-    multi_json (1.9.2)
+    mixlib-shellout (1.4.0)
+    multi_json (1.10.1)
     net-http-spy (0.2.1)
     netrc (0.7.7)
     rdoc (4.1.1)
       json (~> 1.4)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.3)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.3)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
     rspec-rerun (0.1.1)
       rspec (>= 2.11.0)
     rspec_junit_formatter (0.1.6)
@@ -74,3 +74,4 @@ DEPENDENCIES
   chef-pedant!
   oc-chef-pedant!
   rest-client!
+  rspec (~> 2.14.0)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ for details.
 
 There are some tests that only make sense to run in certain environments or that don't make sense to run by default.
 
+#### LDAP Testing
+
+WARNING: Do not perform this testing on a production environment as it interacts with actual LDAP credentials.
+
+You will need LDAP running on your EC test server with a valid LDAP user. Follow the instructions here to get LDAP running with EC http://docs.opscode.com/server_ldap.html.
+
+Please update the entries in multitenant_config.rb. Set `ldap_testing` to true,
+and fill in ldap({}) with your LDAP credentials a user on the test server you pointed EC at above.
+
+This is good enough for quick ad-hoc testing, but we should develop better LDAP integration tests in the future.
+
 #### Account Tests That Talk Via Internal Ports
 
 The opscode-account endpoint for internal org creation and updating (```/internal-organizations```) communicates via the internal account port. That endpoint is not exposed via the external-lb. Therefore, they will fail when kicking off the tests from a point external to the lb (say, developer's laptop hitting hosted for pedant). However, they are useful in validating that these endpoint are still functioning, so if you are running pedant somewhere with access to the internal-lb, simply run

--- a/lib/pedant/multitenant/platform.rb
+++ b/lib/pedant/multitenant/platform.rb
@@ -5,12 +5,14 @@ module Pedant
 
     GLOBAL_OBJECTS = ['users', 'organizations']
 
-    attr_reader :test_org, :test_org_owner, :validate_org, :internal_account_url
+    attr_reader :test_org, :test_org_owner, :validate_org, :internal_account_url, :ldap, :ldap_testing
 
     def initialize(server, superuser_key_file, super_user_name='pivotal')
       super(server, superuser_key_file, super_user_name)
       @test_org = org_from_config
       @internal_account_url = Pedant::Config[:internal_account_url]
+      @ldap = Pedant::Config[:ldap]
+      @ldap_testing = Pedant::Config[:ldap_testing]
     end
 
     # Intelligently construct a complete API URL based on the

--- a/multitenant_config.rb
+++ b/multitenant_config.rb
@@ -70,6 +70,39 @@ maximum_search_time 65
 # value.
 include_internal false
 
+##########################################################
+# LDAP Testing, see the README.md for additional details #
+##########################################################
+
+# Set to true if you wish do LDAP testing on authenticate_user and system_recovery tests
+ldap_testing false
+
+# Fill in the following with correct values for your AD user if ldap_testing is true (directly above)
+# Put :key => nil if there is no value
+ldap({
+       # Change this to your AD samAccountName (i.e., my login name) for your test server
+       :account_name => "your_ldap_account_name",
+       # Change this to your current AD password for your test server
+       :account_password => "your_ldap_password!",
+       # Your first name in AD
+       :first_name => "Firsname",
+       # Your last name in AD
+       :last_name => "Lastname",
+       # Your display name in AD, likely "Firstname Lastname"
+       :display_name => "Firstname Lastname",
+       # Your email in AD
+       :email => "your@email.com",
+       # Likely nil
+       :city => nil,
+       # Likely nil
+       :country => nil,
+       # Set to "linked" or "unlinked" depending on the status of your account in AD
+       :status => "unlinked",
+       # Set to true or false, depending on your user state in Chef itself
+       :recovery_authentication_enabled => false
+     })
+
+
 # Test users.  The five users specified below are required; their
 # names (:user, :non_org_user, etc.) are indicative of their role
 # within the tests.  All users must have a ':name' key.  If they have

--- a/spec/api/system_recovery_spec.rb
+++ b/spec/api/system_recovery_spec.rb
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+#
+# Author:: Tyler Cloke (<tyler@getchef.com>)
+# Copyright:: Copyright (c) 2014 Chef, Inc.
+
+# TODO: there is no LDAP testing here because to
+# accurately simulate the real use case, we would need
+# the chef-server pedant is running on to be LDAP configured,
+# and we would want that LDAP server to be down.
+#
+# This is too intergration-test-ish for pedant, but it is a case
+# we should be testing. It'd be great if our CI test spun up an
+# AD server, then configured and ran these tests with an LDAP user.
+#
+# LDAP status is not expected to affect this endpoint in any way
+# but we would obviously want to test the server in a state we
+# actually expect to see when this endpoint would be used in the real world.
+#
+# Basically what I'm saying is we should have integration testing and
+# that pedant is the wrong place to do such an infrastructure / service-interactive test.
+describe 'system_recovery' do
+
+  let(:external_auth_id) {
+    "#{Time.now.to_i}-#{Process.pid}"  }
+
+  let(:username) {
+    "recoverable_user-#{external_auth_id}"
+  }
+
+  let(:password) {
+    "foobar"
+  }
+
+  let(:create_body) do
+    {
+      display_name: username,
+      email: "#{username}@getchef.com",
+      password: password,
+      username: username,
+      external_auth_id: external_auth_id,
+      recovery_authentication_enabled: true
+    }
+  end
+
+  let (:user_body) {
+    {
+      'username' => username,
+      'password' => password
+    }
+  }
+
+  let (:request_url) { "#{platform.server}/system_recovery" }
+
+  # create a new recovery_authentication_enabled:true user
+  before :each do
+    post("#{platform.server}/users", superuser, :payload => create_body)
+  end
+
+  # delete the user after test
+  after :each do
+    delete("#{platform.server}/users/#{username}", superuser)
+  end
+
+  describe "POST /system_recovery" do
+
+    context "when a user has recovery_authentication_enabled == true is requested" do
+
+      context "when the superuser is the requestor" do
+
+        it "should return the user body" do
+          post(request_url, superuser, :payload => user_body).should look_like(
+            :body => {
+              "display_name" => username,
+              "username" => username,
+              "email" => "#{username}@getchef.com",
+              "recovery_authentication_enabled" => true
+            },
+            :status => 200
+          )
+        end # should return the user body
+      end # when the superuser is the requestor
+
+      context "when the pasword passed is incorrect" do
+        let (:wrong_pw_user_body) {
+          { 'username' => username,
+            'password' => "wrong_password"
+          }
+        }
+
+        # TODO: opscode-account currently returns "Failed to authenticate: ".
+        # It is executing "Failed to authenticate: #{$!}", so it is intending to
+        # print the exception here, but we should have a more meanful message, see
+        # below for an example:
+        #
+        # Failed to authenticated as #{username}. Password passed is incorrect.
+        it "should return 401 with an error message" do
+          post(request_url, superuser, :payload => wrong_pw_user_body).should look_like(
+            :body => {
+              "error" => "Failed to authenticate: "
+            },
+            :status => 401
+          )
+        end # should return 403 with an error message
+      end # when the pasword passed is incorrect
+
+      context "when a non-superuser is the requestor" do
+
+        # TODO: the error string from opscode-account returns
+        # the user in the body and not the requestor user
+        it "should return 403 with an error explaining non-superuser is not authorized" do
+          post(request_url, platform.admin_user, :payload => user_body).should look_like(
+            :body => {
+              "error" => "#{username} not authorized for verify_password"
+            },
+            :status => 403
+          )
+        end # should return 403 with an error explaining non-superuser is not authorized
+      end # when a non-superuser is the requestor
+    end # when a user has recovery_authentication_enabled == true is requested
+
+
+    context "when a user has recovery_authentication_enabled != true is requested by the superuser" do
+
+      let(:unrecoverable_external_auth_id) { "#{Time.now.to_i}-#{Process.pid}" }
+
+      let(:unrecoverable_username) { "unrecoverable_user-#{unrecoverable_external_auth_id}" }
+
+      let(:unrecoverable_user_create_body) do
+        {
+          display_name: unrecoverable_username,
+          email: "#{unrecoverable_username}@getchef.com",
+          password: "foobar",
+          username: unrecoverable_username,
+          external_auth_id: unrecoverable_external_auth_id,
+          recovery_authentication_enabled: false
+        }
+      end
+
+      let (:unrecoverable_user_body) {
+        { 'username' => unrecoverable_username,
+          'password' => "foobar"
+        }
+      }
+
+      # create a new recovery_authentication_enabled:false user
+      before :each do
+        post("#{platform.server}/users", superuser, :payload => unrecoverable_user_create_body)
+      end
+
+      # delete the user after test
+      after :each do
+        delete("#{platform.server}/users/#{unrecoverable_username}", superuser)
+      end
+
+      it "should return 403 with a relevant error message" do
+        post(request_url, superuser, :payload => unrecoverable_user_body).should look_like(
+          # TODO: this error isn't quite terrible enough to mark test as pending,
+          # but it should be "Requestor" not "User"
+          :body => {
+            "error" => "User is not allowed to take this action"
+          },
+          :status => 403
+        )
+      end # should return 403 with a relevant error message
+    end # when a user has recovery_authentication_enabled != true is requested by the superuser
+
+    context "when a user that does not exist is requested by the superuser" do
+
+      let (:user_body) {
+        {
+          'username' => 'this_user_does_not_exist-#{Time.now.to_i}-#{Process.pid}',
+          'password' => password
+        }
+      }
+
+      it "should return 404 with an error message" do
+        post(request_url, superuser, :payload => user_body).should look_like(
+          :body => {
+            "error" => "User is not found in the system"
+          },
+          :status => 404
+        )
+      end # should return 404 with an error message
+    end # when a user that does not exist is requested by the superuser
+
+    context "when the request is missing the username field" do
+
+      let (:missing_username_body) {
+        {
+          'password' => "foobar"
+        }
+      }
+
+      it "should return 400 with an error message" do
+        post(request_url, superuser, :payload => missing_username_body).should look_like(
+          :body => {
+            "error" => "username and password are required"
+          },
+          :status => 400
+        )
+      end # should return 400 with an error message
+    end # when the request is missing the username field
+
+    context "when the request is missing the password field" do
+
+      let (:missing_username_body) {
+        {
+          "username" => username
+        }
+      }
+
+      it "should return 400 with an error message" do
+        post(request_url, superuser, :payload => missing_username_body).should look_like(
+          :body => {
+            "error" => "username and password are required"
+          },
+          :status => 400
+        )
+      end # should return 400 with an error message
+    end # when the request is missing the password field
+
+  end # POST /system_recovery
+end # system_recovery


### PR DESCRIPTION
I marked a few of the tests I just wrote as pending because the errors from `opscode-account` make no sense. I wrote error messages that made sense and marked the relevant tests as pending.

I also generalized the comments about manual LDAP testing in `/authenticate_user` into documentation and added some configuration around LDAP testing. See TODO comment in the `/system_recovery` to see what I didn't implement any LDAP testing for that endpoint.

Added a wiki entry for testing LDAP with our AD server: 

http://wiki.corp.opscode.com/display/CORP/LDAP+testing+with+oc-chef-pedant+via+opscodedev+AD+server#

Ping @opscode/server-team 
