### PR TITLE
Added spec to test license endpoint

### DIFF
--- a/spec/api/license_spec.rb
+++ b/spec/api/license_spec.rb
@@ -17,7 +17,7 @@ describe 'license' do
       "limit_exceeded" => (node_count > 25) ? true : false,
       "node_license" => 25,
       "node_count" => node_count,
-      "upgrade_url" => "http://example.com"
+      "upgrade_url" => /^http\:\/\.*/
     }}
 
   context "GET /license" do
@@ -86,7 +86,7 @@ describe 'license' do
         end
       end # with one node
 
-      context "with twenty-five nodes" do
+      context "with twenty-five nodes (license not exceeded)" do
         let(:node_count) { 25 }
 
         it "should return correct body for license status" do
@@ -97,7 +97,7 @@ describe 'license' do
         end
       end # with twenty nodes
 
-      context "with twenty-six nodes" do
+      context "with twenty-six nodes (license exceeded)" do
         let(:node_count) { 26 }
 
         it "should return correct body for license status" do


### PR DESCRIPTION
New spec for testing license endpoint; assumes a default license for 25 nodes, so tests for access and correct results for 0, 1, 25 (license limit) and 26 (license + 1) nodes.

Requires https://github.com/opscode/oc_chef_wm/pull/84 and https://github.com/opscode/chef_db/pull/54
