### PR TITLE
Dt/acl

### DIFF
--- a/spec/api/account/account_acl_spec.rb
+++ b/spec/api/account/account_acl_spec.rb
@@ -7,6 +7,7 @@ describe "ACL API", :acl do
   end
 
   let(:unsupported_method_status) {
+    # Organizations don't use this yet, still routed to opscode-account
     if (ruby?)
       404
     else
@@ -268,7 +269,7 @@ describe "ACL API", :acl do
       end
 
       #
-      # There's a clause 'with modified acls' for organization objects below that should be extended
+      # There's a clause 'with modified acls' for organizations objects below that should be extended
       # here, but some of the semantics around what they should be are unclear to me
       #
 
@@ -276,10 +277,10 @@ describe "ACL API", :acl do
     end
   end
 
-  context "/organization/_acl endpoint" do
-    let(:request_url) { api_url("organization/_acl") }
+  context "/organizations/_acl endpoint" do
+    let(:request_url) { api_url("organizations/_acl") }
 
-    context "GET /organization/_acl" do
+    context "GET /organizations/_acl" do
       let(:actors) { ["pivotal"] }
       let(:groups) { ["admins"] }
       let(:read_groups) { ["admins", "users"] }
@@ -353,7 +354,7 @@ describe "ACL API", :acl do
 
         context "when normal user granted all permissions except GRANT" do
           it "returns 403" do
-            restrict_permissions_to("organization",
+            restrict_permissions_to("organizations",
               platform.non_admin_user => ['create', 'read', 'update', 'delete'])
             get(request_url, platform.non_admin_user).should look_like({
                 :status => 403
@@ -363,7 +364,7 @@ describe "ACL API", :acl do
 
         context "when normal client granted all permisions except GRANT" do
           it "returns 403", :smoke do
-            restrict_permissions_to("organization",
+            restrict_permissions_to("organizations",
               platform.non_admin_client => ['create', 'read', 'update', 'delete'])
             get(request_url, platform.non_admin_client).should look_like({
                 :status => 403
@@ -373,7 +374,7 @@ describe "ACL API", :acl do
 
         context "when normal user granted GRANT permission" do
           it "can get ACL" do
-            restrict_permissions_to("organization",
+            restrict_permissions_to("organizations",
               platform.non_admin_user => ['grant'])
             get(request_url, platform.non_admin_user).should look_like({
                 :status => 200
@@ -383,7 +384,7 @@ describe "ACL API", :acl do
 
         context "when normal client granted GRANT permision" do
           it "can get ACL", :smoke do
-            restrict_permissions_to("organization",
+            restrict_permissions_to("organizations",
               platform.non_admin_client => ['grant'])
             get(request_url, platform.non_admin_client).should look_like({
                 :status => 200
@@ -391,41 +392,41 @@ describe "ACL API", :acl do
           end
         end
       end # context with modified ACLs
-    end # context GET /organization/_acl
+    end # context GET /organizations/_acl
 
-    context "PUT /organization/_acl" do
+    context "PUT /organizations/_acl" do
       context "admin user" do
         it "returns 405" do
           put(request_url, platform.admin_user).should look_like({
-              :status => unsupported_method_status
+              :status => 404
             })
         end
       end
-    end # context PUT /organization/_acl
+    end # context PUT /organizations/_acl
 
-    context "POST /organization/_acl" do
+    context "POST /organizations/_acl" do
       context "admin user" do
         it "returns 405" do
           post(request_url, platform.admin_user).should look_like({
-              :status => unsupported_method_status
+              :status => 404
             })
         end
       end
-    end # context POST /organization/_acl
+    end # context POST /organizations/_acl
 
-    context "DELETE /organization/_acl" do
+    context "DELETE /organizations/_acl" do
       context "admin user" do
         it "returns 405" do
           delete(request_url, platform.admin_user).should look_like({
-              :status => unsupported_method_status
+              :status => 404
             })
         end
       end
-    end # context DELETE /organization/_acl
-  end # context /organization/_acl endpoint
+    end # context DELETE /organizations/_acl
+  end # context /organizations/_acl endpoint
 
   ["create", "read", "update", "delete", "grant"].each do |permission|
-    context "/organization/_acl/#{permission} endpoint" do
+    context "/organizations/_acl/#{permission} endpoint" do
       # Don't run a smoke test test for every permission (to keep the smoke test count
       # from being unnecessarily repetetive)
       if (permission == "read")
@@ -434,10 +435,10 @@ describe "ACL API", :acl do
         smoketest = :notsmoke
       end
 
-      let(:acl_url) { api_url("organization/_acl") }
-      let(:request_url) { api_url("organization/_acl/#{permission}") }
+      let(:acl_url) { api_url("organizations/_acl") }
+      let(:request_url) { api_url("organizations/_acl/#{permission}") }
 
-      context "PUT /organization/_acl/#{permission}" do
+      context "PUT /organizations/_acl/#{permission}" do
         let(:actors) { ["pivotal"] }
         let(:groups) { ["admins"] }
         let(:read_groups) { ["admins", "users"] }
@@ -656,7 +657,7 @@ describe "ACL API", :acl do
           context "when normal user granted all permissions except GRANT" do
             # We only run the smoke tests for read permission (set above)
             it "returns 403" do
-              restrict_permissions_to("organization",
+              restrict_permissions_to("organizations",
                 platform.non_admin_user => ['create', 'read', 'update', 'delete'])
               put(request_url, platform.non_admin_user,
                 :payload => request_body).should look_like({
@@ -668,7 +669,7 @@ describe "ACL API", :acl do
           context "when normal client granted all permisions except GRANT" do
             # We only run the smoke tests for read permission (set above)
             it "returns 403" do
-              restrict_permissions_to("organization",
+              restrict_permissions_to("organizations",
                 platform.non_admin_client => ['create', 'read', 'update', 'delete'])
               put(request_url, platform.non_admin_client,
                 :payload => request_body).should look_like({
@@ -680,7 +681,7 @@ describe "ACL API", :acl do
           context "when normal user granted GRANT permission" do
             # We only run the smoke tests for read permission (set above)
             it "can modify ACL", smoketest do
-              restrict_permissions_to("organization",
+              restrict_permissions_to("organizations",
                 platform.non_admin_user => ['grant'])
               put(request_url, platform.non_admin_user,
                 :payload => request_body).should look_like({
@@ -692,7 +693,7 @@ describe "ACL API", :acl do
           context "when normal client granted GRANT permision" do
             # We only run the smoke tests for read permission (set above)
             it "can modify ACL" do
-              restrict_permissions_to("organization",
+              restrict_permissions_to("organizations",
                 platform.non_admin_client => ['grant'])
               put(request_url, platform.non_admin_client,
                 :payload => request_body).should look_like({
@@ -701,37 +702,37 @@ describe "ACL API", :acl do
             end
           end
         end # context with modified ACLs
-      end # context PUT /organization/_acl/<permission>
+      end # context PUT /organizations/_acl/<permission>
 
-      context "GET /organization/_acl/#{permission}" do
+      context "GET /organizations/_acl/#{permission}" do
         context "admin user" do
           it "returns 405" do
             get(request_url, platform.admin_user).should look_like({
-                :status => unsupported_method_status
+                :status => 404
               })
           end
         end
-      end # context GET /organization/_acl/<permission>
+      end # context GET /organizations/_acl/<permission>
 
-      context "POST /organization/_acl/#{permission}" do
+      context "POST /organizations/_acl/#{permission}" do
         context "admin user" do
           it "returns 405" do
             post(request_url, platform.admin_user).should look_like({
-                :status => unsupported_method_status
+                :status => 404
               })
           end
         end
-      end # context POST /organization/_acl/<permission>
+      end # context POST /organizations/_acl/<permission>
 
-      context "DELETE /organization/_acl/#{permission}" do
+      context "DELETE /organizations/_acl/#{permission}" do
         context "admin user" do
           it "returns 405" do
             delete(request_url, platform.admin_user).should look_like({
-                :status => unsupported_method_status
+                :status => 404
               })
           end
         end
-      end # context DELETE /organization/_acl/<permission>
+      end # context DELETE /organizations/_acl/<permission>
     end # context /organizations/_acl/<permission> endpoint
   end # loop (each) over permissions
 


### PR DESCRIPTION
Changes to support ACL endpoints in erlang (all but organization: ORG/organizations/_acl):
- Added switch (via variable) for 404 versus 405 on unsupported endpoints (then backed it out for orgs)
- Changed organization to organizations globally (since we only route the latter to account)

NOTE: this adds an additional config item to pedant config for this endpoint to toggle 404/405.

Requires:
https://github.com/opscode/oc_chef_wm/pull/88
