### PR TITLE
Added option to disable license endpoint tests

### DIFF
--- a/spec/api/license_spec.rb
+++ b/spec/api/license_spec.rb
@@ -20,93 +20,109 @@ describe 'license' do
       "upgrade_url" => /^http\:\/\.*/
     }}
 
-  context "GET /license" do
-    context "with no nodes" do
+  if (Pedant::Config.license_endpoint?)
+    context "GET /license" do
+      context "with no nodes" do
 
-      it "returns 200 and correct body for superuser" do
+        it "returns 200 and correct body for superuser" do
+          get(request_url, superuser).should look_like(
+            :body_exact => response_body,
+            :status => 200
+            )
+        end
+
+        it "returns 200 and correct body for admin user" do
+          get(request_url, platform.admin_user).should look_like(
+            :body_exact => response_body,
+            :status => 200
+            )
+        end
+
+        it "returns 200 and correct body for normal user" do
+          get(request_url, platform.non_admin_user).should look_like(
+            :body_exact => response_body,
+            :status => 200
+            )
+        end
+
+        it "returns 401 for invalid user", :authentication do
+          get(request_url, invalid_user).should look_like(
+            :status => 401
+            )
+        end
+
+        it "returns 401 for client", :authentication do
+          get(request_url, platform.non_admin_client).should look_like(
+            :status => 401
+            )
+        end
+
+      end # with no nodes
+
+      context "with nodes" do
+        let(:nodes) do
+          (1..node_count).map{|i| new_node(unique_name("pedant_node_list_test_#{i}"))}
+        end
+
+        before :each do
+          nodes.each do |n|
+            add_node(platform.admin_user, n)
+          end
+        end
+
+        after :each do
+          nodes.each do |n|
+            delete_node(platform.admin_user, n['name'])
+          end
+        end
+
+        context "with one node" do
+          let(:node_count) { 1 }
+
+          it "should return correct body for license status" do
+            get(request_url, superuser).should look_like(
+              :body_exact => response_body,
+              :status => 200
+              )
+          end
+        end # with one node
+
+        context "with twenty-five nodes (license not exceeded)" do
+          let(:node_count) { 25 }
+
+          it "should return correct body for license status" do
+            get(request_url, superuser).should look_like(
+              :body_exact => response_body,
+              :status => 200
+              )
+          end
+        end # with twenty nodes
+
+        context "with twenty-six nodes (license exceeded)" do
+          let(:node_count) { 26 }
+
+          it "should return correct body for license status" do
+            get(request_url, superuser).should look_like(
+              :body_exact => response_body,
+              :status => 200
+              )
+          end
+        end # with thirty nodes
+      end # with nodes
+    end # GET /license
+
+  else
+
+    # This is a sanity check to make sure that the pedant configuration correctly
+    # turns on this spec with the license? setting when the license endpoint is
+    # present
+
+    context "verify no license endpoint" do
+      it "returns 404" do
         get(request_url, superuser).should look_like(
-          :body_exact => response_body,
-          :status => 200
+          :status => 404
           )
       end
-
-      it "returns 200 and correct body for admin user" do
-        get(request_url, platform.admin_user).should look_like(
-          :body_exact => response_body,
-          :status => 200
-          )
-      end
-
-      it "returns 200 and correct body for normal user" do
-        get(request_url, platform.non_admin_user).should look_like(
-          :body_exact => response_body,
-          :status => 200
-          )
-      end
-
-      it "returns 401 for invalid user", :authentication do
-        get(request_url, invalid_user).should look_like(
-          :status => 401
-          )
-      end
-
-      it "returns 401 for client", :authentication do
-        get(request_url, platform.non_admin_client).should look_like(
-          :status => 401
-          )
-      end
-
-    end # with no nodes
-
-    context "with nodes" do
-      let(:nodes) do
-        (1..node_count).map{|i| new_node(unique_name("pedant_node_list_test_#{i}"))}
-      end
-
-      before :each do
-        nodes.each do |n|
-          add_node(platform.admin_user, n)
-        end
-      end
-
-      after :each do
-        nodes.each do |n|
-          delete_node(platform.admin_user, n['name'])
-        end
-      end
-
-      context "with one node" do
-        let(:node_count) { 1 }
-
-        it "should return correct body for license status" do
-          get(request_url, superuser).should look_like(
-            :body_exact => response_body,
-            :status => 200
-            )
-        end
-      end # with one node
-
-      context "with twenty-five nodes (license not exceeded)" do
-        let(:node_count) { 25 }
-
-        it "should return correct body for license status" do
-          get(request_url, superuser).should look_like(
-            :body_exact => response_body,
-            :status => 200
-            )
-        end
-      end # with twenty nodes
-
-      context "with twenty-six nodes (license exceeded)" do
-        let(:node_count) { 26 }
-
-        it "should return correct body for license status" do
-          get(request_url, superuser).should look_like(
-            :body_exact => response_body,
-            :status => 200
-            )
-        end
-      end # with thirty nodes
-    end # with nodes
-  end # GET /license
+    end
+  end
 end # license


### PR DESCRIPTION
For versions before Chef 12 (which don't have license tests).

Added test to run when license endpoint doesn't exist (for sanity, to make sure they aren't disabled when they shouldn't be.)
