### PR TITLE
when admin self-removal fails, nothing should break

### DIFF
--- a/oc-chef-pedant.gemspec
+++ b/oc-chef-pedant.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = 'oc-chef-pedant'
-  s.version       = '1.0.62'
-  s.date          = '2014-10-17'
+  s.version       = '1.0.63'
+  s.date          = '2014-11-04'
   s.summary       = "Enterprise Chef API Testing Framework"
   s.authors       = ["Chef Software Engineering"]
   s.email         = 'dev@getchef.com'


### PR DESCRIPTION
- ensure that after an admin user fails to disassociate, that user's
  access still works as it should.
- ensure before/after in these tests are :each so that we start each one
  in a known clean state.

Requires https://github.com/opscode/oc_chef_wm/pull/107 to pass
