### PR TITLE
turn off org creation validation by default

### DIFF
--- a/lib/pedant/multitenant/platform.rb
+++ b/lib/pedant/multitenant/platform.rb
@@ -219,18 +219,10 @@ module Pedant
       MAX_ATTEMPTS.times do |attempt|
         r = post("#{@server}/organizations", superuser, :payload => payload)
 
-        # This re-assigns the variable 'r' and therefore can't be part of the case statement below
-        if r.code == 409
-          puts "The organization already exists!  Regenerating validator key ..."
-          r = post("#{Pedant::Config.account_server}/organizations/#{orgname}/_validator_key", superuser, {})
-          raise "Bad error code #{r.code} from regenerating validator key: #{r}" unless r.code == 200
-        end
-
         case r.code
         when 201, 200
           parsed = parse(r)
-          # If we came here through the 409 codepath there won't be a client name so we're hardcoding it.
-          validator_name = parsed["clientname"] || "#{orgname}-validator"
+          validator_name = parsed["clientname"]
           validator_key = parsed["private_key"]
 
           validator = Pedant::Client.new(validator_name, validator_key)


### PR DESCRIPTION
This commit disables the functionality that runs org creation
validation on every pedant run that targets the multitenant
platform. By disabling this as the default, these tests will no
longer be run or break from add-ons that consume oc-chef-pedant
and its libraries, such as oc-reporting-pedant and
oc-pushy-pedant.

The code that is executed in said tests is tightly coupled to
the version of the Chef Server that they ship with, and running
such tests from an add-on can result in failures if the add-on
is not also tightly coupled to the Chef Server version. This
commit removes that tight coupling.

This commit will require an update to the pedant config on
Chef Server that adds:

```
verify_org_creation true
```
