### PR TITLE
Cookbook Artifact Endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,5 @@ gemspec
 gem 'rspec', '~> 3.1'
 gem "rest-client", :git => "git://github.com/opscode/rest-client.git"
 
-# Restore this once we update pedant
-gem 'chef-pedant', :git => "git://github.com/opscode/chef-pedant.git", :tag => '1.0.41'
+gem 'chef-pedant', git: "git://github.com/opscode/chef-pedant.git", tag: '1.0.42'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git://github.com/opscode/chef-pedant.git
-  revision: 57ce9e9681009a721d256ca0f3125120a42d9f03
-  tag: 1.0.41
+  revision: cf94ba9d2402e2541c112854136a04e215ef0209
+  tag: 1.0.42
   specs:
-    chef-pedant (1.0.41)
+    chef-pedant (1.0.42)
       activesupport (~> 3.2.8)
       erubis (~> 2.7.0)
       mixlib-authentication (~> 1.3.0)
@@ -28,7 +28,7 @@ GIT
 PATH
   remote: .
   specs:
-    oc-chef-pedant (1.0.72)
+    oc-chef-pedant (1.0.73)
       chef-pedant (>= 1.0.0)
 
 GEM

--- a/spec/api/cookbooks_spec.rb
+++ b/spec/api/cookbooks_spec.rb
@@ -13,6 +13,8 @@ require 'pedant/rspec/cookbook_util'
 describe "Cookbooks API endpoint", :cookbooks do
   include Pedant::RSpec::CookbookUtil
 
+  let(:cookbook_url_base) { "cookbooks" }
+
   context "DELETE /cookbooks/<name>/<version>" do
     let(:request_method) { :DELETE }
     let(:request_url)    { named_cookbook_url }


### PR DESCRIPTION
Adds tests for the cookbook artifact API endpoint, via https://github.com/chef/chef-pedant/pull/97 (one small fix required here). Initially, this endpoint is identical to the existing endpoint, but we'll be modifying the behavior in subsequent pull requests.

@chef/lob @chef/delivery 