### PR TITLE
remove ruby and non-chef12 behaviors

### DIFF
--- a/lib/pedant/platform.rb
+++ b/lib/pedant/platform.rb
@@ -388,7 +388,7 @@ module Pedant
 
     def associate_user_with_org(orgname, user)
       r = post("#{@server}/organizations/#{orgname}/users", superuser, :payload => { "username" => user.name })
-      if r.code == 201 && r.code == 409 && parse(r)["error"] == "The association already exists."
+      if r.code == 201 or (r.code == 409 and parse(r)["error"] == "The association already exists.")
         r
       else
         raise "Bad response #{r.code} from POST /organizations/#{orgname}/users w/ { 'username' : '#{user.name}'}: #{r}"

--- a/lib/pedant/platform.rb
+++ b/lib/pedant/platform.rb
@@ -387,38 +387,11 @@ module Pedant
     end
 
     def associate_user_with_org(orgname, user)
-      if Pedant::Config.ruby_org_assoc?
-        associate_user_with_org_rubynam_style(orgname, user)
+      r = post("#{@server}/organizations/#{orgname}/users", superuser, :payload => { "username" => user.name })
+      if r.code == 201 && r.code == 409 && parse(r)["error"] == "The association already exists."
+        r
       else
-        payload = { "username" => user.name }
-        r = post("#{@server}/organizations/#{orgname}/users", superuser, :payload => payload )
-        if r.code == 201 or r.code == 409
-          r
-        else
-          raise "Bad response #{r.code} from POST /organizations/#{orgname}/users with #{payload} :#{r}"
-        end
-      end
-    end
-
-    def associate_user_with_org_rubynam_style(orgname, user)
-      payload = { "user" => user.name }
-      association_requests_url = "#{@server}/organizations/#{orgname}/association_requests"
-      r = post("#{association_requests_url}",  superuser, :payload => payload)
-      if r.code == 201 # Created
-        association_id = parse(r)["uri"].split("/").last
-        r = put("#{@server}/users/#{user.name}/association_requests/#{association_id}", user, :payload => { "response" => "accept" })
-        if r.code != 200
-          raise "Bad response #{r.code} from PUT /users/#{user.name}/association_requests/#{association_id}: #{r}"
-        end
-        # Check that the user was really added, because we're paranoid like that.
-        r = get("#{@server}/organizations/#{orgname}/users", superuser)
-        if r.code != 200 || !parse(r).any? { |u| u['user']['username'] == user.name }
-          raise "Organization invite process did not work for #{orgname} + #{user.name}!  Response: #{r}"
-        end
-      elsif r.code == 409 && parse(r)["error"] == "The association already exists."
-        # No problem!
-      else
-        raise "Bad response #{r.code} from POST /organizations/#{orgname}/association_requests: #{r}"
+        raise "Bad response #{r.code} from POST /organizations/#{orgname}/users w/ { 'username' : '#{user.name}'}: #{r}"
       end
     end
 

--- a/lib/pedant/rspec/common.rb
+++ b/lib/pedant/rspec/common.rb
@@ -299,27 +299,6 @@ module Pedant
 
         end # test_run_list_corner_cases
 
-
-
-
-        # Ruby endpoint magic
-        # This will still be needed for users, etc. This can be removed when
-        # everything has been ported to Erlang
-
-        # If let() is working properly, then you only need to define self.ruby? in
-        # the specific endpoints. Example:
-        #
-        #     def self.ruby?
-        #       Pedant::Config.ruby_users_endpoint?
-        #     end
-
-        let(:ruby?) { self.class.ruby? }
-        let(:erlang?) { not ruby? }
-
-        def self.erlang?
-          not ruby?
-        end
-
         # Timestamp suffixes
         # Suffix unique between runs. Timestamp is generated once per pedant run
         shared(:pedant_suffix) { suffix_for_names.(platform.pedant_run_timestamp) }

--- a/lib/pedant/rspec/cookbook_util.rb
+++ b/lib/pedant/rspec/cookbook_util.rb
@@ -415,6 +415,7 @@ module Pedant
       # with keys `:name` and `:content`, where the content key is a
       # string that will be used as the recipe file contents.
       #
+      # TODO - but no dependency on ruby flag, so...
       # NOTE: Recipe names are sorted here to accommodate differences
       # between the Ruby and Erlang implementations; when retrieving
       # recipe names (e.g. /environments/ENVIRONMENT/recipes), the results
@@ -573,25 +574,6 @@ module Pedant
           should_fail_to_change(key, value, error, message, false, true)
         end
 
-        # This is used when the key/value pair change/addition for a
-        # cookbook create results in an internal server error -- this should
-        # only really be relevant for testing agains ruby endpoint
-        #   key:     key to change
-        #   value:   value to use
-        def create_should_crash_server(key, value)
-          # Well, obviously it SHOULD'T, but that's what the ruby endpoint does!  Yay!
-          should_fail_to_change(key, value, 500, nil, true, true)
-        end
-
-        # This is used when the key/value pair change/addition for a
-        # cookbook update results in an internal server error -- this should
-        # only really be relevant for testing agains ruby endpoint
-        #   key:     key to change
-        #   value:   value to use
-        def update_should_crash_server(key, value)
-          should_fail_to_change(key, value, 500, nil, true)
-        end
-
         # This is used when the update operation is expected to fail; the
         # key/value pair is added/modified in the default new_cookbook, but
         # the error and message are expected instead of 200 (success) and a
@@ -725,24 +707,6 @@ module Pedant
         #   message: error message expected
         def should_fail_to_create_metadata(key, value, error, message)
           should_fail_to_change_metadata(key, value, error, message, true)
-        end
-
-        # This is used for cases where metadata changes to the default
-        # cookbook on creation cause internal server errors -- this is only
-        # really relevant for the ruby endpoint
-        #   key:     key to change
-        #   value:   value to use
-        def create_metadata_should_crash_server(key, value)
-          should_fail_to_change_metadata(key, value, 500, nil, true, true)
-        end
-
-        # This is used for cases where metadata changes to the default
-        # cookbook on update cause internal server errors -- this is only
-        # really relevant for the ruby endpoint
-        #   key:     key to change
-        #   value:   value to use
-        def update_metadata_should_crash_server(key, value)
-          should_fail_to_change_metadata(key, value, 500, nil, false, true)
         end
 
         # This is used for testing updates with changes to the default

--- a/lib/pedant/rspec/search_util.rb
+++ b/lib/pedant/rspec/search_util.rb
@@ -688,18 +688,9 @@ module Pedant
         # time to clear the queue.  In a test scenario, this
         # should be enough of a wait.
         sleep direct_solr_query_sleep_time
-        if Pedant::Config.chef_12?
-          url = "#{Pedant::Config.search_server}/solr/update?commit=true"
-          body = ''
-          headers = {}
-        else
-          url = "#{Pedant::Config.search_server}/solr/update"
-          body = '<commit waitSearcher="true" waitFlush="true" softCommit="false"/>'
-          headers = {
-            "Content-Type" => "application/xml",
-            "Accept" => "application/xml"
-          }
-        end
+        url = "#{Pedant::Config.search_server}/solr/update?commit=true"
+        body = ''
+        headers = {}
         RestClient.send :post, url, body, headers
       end
 

--- a/pedant_config.rb
+++ b/pedant_config.rb
@@ -195,24 +195,7 @@ debug_org_creation false
 # necessary.  A common reason is to take into account different error
 # message formatting between the two implementations.
 #
-ruby_environment_endpoint? false
-ruby_sandbox_endpoint?     false
-ruby_data_endpoint?        false
-ruby_role_endpoint?        false
-ruby_cookbook_endpoint?    false
-ruby_client_endpoint?      false
-ruby_users_endpoint?       false
-ruby_container_endpoint?   false
-ruby_container_endpoint_in_sql? true
-ruby_group_endpoint?       false
-ruby_acl_endpoint?         false
-ruby_system_recovery_endpoint? false
-ruby_org_acl_endpoint?     false
-ruby_org_assoc?            false
-ruby_organizations_endpoint? false
-chef_12?                   true
 policies?                  true
-
 old_runlists_and_search true
 
 

--- a/pedant_config.rb
+++ b/pedant_config.rb
@@ -195,7 +195,6 @@ debug_org_creation false
 # necessary.  A common reason is to take into account different error
 # message formatting between the two implementations.
 #
-policies?                  true
 old_runlists_and_search true
 
 

--- a/spec/api/account/account_acl_spec.rb
+++ b/spec/api/account/account_acl_spec.rb
@@ -4,27 +4,6 @@ require 'pedant/acl'
 describe "ACL API", :acl do
   include Pedant::ACL
 
-  def self.ruby?
-    Pedant::Config.ruby_acl_endpoint?
-  end
-
-  let(:unsupported_method_status) {
-    # Organizations don't use this yet, still routed to opscode-account
-    if (ruby?)
-      404
-    else
-      405
-    end
-  }
-
-  let(:org_unsupported_method_status) {
-    if Pedant::Config.ruby_org_acl_endpoint?
-      404
-    else
-      405
-    end
-  }
-
   # (temporarily?) deprecating /users/*/_acl endpoint due to its broken state and lack of usefulness
   skip "/users/<name>/_acl endpoint" do
     let(:username) { platform.admin_user.name }
@@ -426,7 +405,7 @@ describe "ACL API", :acl do
       context "admin user" do
         it "returns 405" do
           put(request_url, platform.admin_user).should look_like({
-              :status => org_unsupported_method_status
+              :status => 405
             })
         end
       end
@@ -436,7 +415,7 @@ describe "ACL API", :acl do
       context "admin user" do
         it "returns 405" do
           post(request_url, platform.admin_user).should look_like({
-              :status => org_unsupported_method_status
+              :status => 405
             })
         end
       end
@@ -446,7 +425,7 @@ describe "ACL API", :acl do
       context "admin user" do
         it "returns 405" do
           delete(request_url, platform.admin_user).should look_like({
-              :status => org_unsupported_method_status
+              :status => 405
             })
         end
       end
@@ -736,7 +715,7 @@ describe "ACL API", :acl do
         context "admin user" do
           it "returns 405" do
             get(request_url, platform.admin_user).should look_like({
-                :status => org_unsupported_method_status
+                :status => 405
               })
           end
         end
@@ -746,7 +725,7 @@ describe "ACL API", :acl do
         context "admin user" do
           it "returns 405" do
             post(request_url, platform.admin_user).should look_like({
-                :status => org_unsupported_method_status
+                :status => 405
               })
           end
         end
@@ -756,7 +735,7 @@ describe "ACL API", :acl do
         context "admin user" do
           it "returns 405" do
             delete(request_url, platform.admin_user).should look_like({
-                :status => org_unsupported_method_status
+                :status => 405
               })
           end
         end
@@ -1044,7 +1023,7 @@ describe "ACL API", :acl do
           context "admin user" do
             it "returns 405" do
               put(request_url, platform.admin_user).should look_like({
-                  :status => unsupported_method_status
+                  :status => 405
                 })
             end
           end
@@ -1054,7 +1033,7 @@ describe "ACL API", :acl do
           context "admin user" do
             it "returns 405" do
               post(request_url, platform.admin_user).should look_like({
-                  :status => unsupported_method_status
+                  :status => 405
                 })
             end
           end
@@ -1064,7 +1043,7 @@ describe "ACL API", :acl do
           context "admin user" do
             it "returns 405" do
               delete(request_url, platform.admin_user).should look_like({
-                  :status => unsupported_method_status
+                  :status => 405
                 })
             end
           end
@@ -1087,7 +1066,7 @@ describe "ACL API", :acl do
               context "admin user" do
                 it "returns 405" do
                   get(permission_request_url, platform.admin_user).should look_like({
-                      :status => unsupported_method_status
+                      :status => 405
                     })
                 end
               end
@@ -1353,7 +1332,7 @@ describe "ACL API", :acl do
               context "admin user" do
                 it "returns 405" do
                   post(permission_request_url, platform.admin_user).should look_like({
-                      :status => unsupported_method_status
+                      :status => 405
                     })
                 end
               end
@@ -1363,7 +1342,7 @@ describe "ACL API", :acl do
               context "admin user" do
                 it "returns 405" do
                   delete(permission_request_url, platform.admin_user).should look_like({
-                      :status => unsupported_method_status
+                      :status => 405
                     })
                 end
               end

--- a/spec/api/account/account_group_spec.rb
+++ b/spec/api/account/account_group_spec.rb
@@ -4,10 +4,6 @@ require 'pedant/rspec/common'
 describe "opscode-account groups", :groups do
   let(:org)        { platform.test_org.name }
 
-  def self.ruby?
-    Pedant::Config.ruby_group_endpoint?
-  end
-
   context "/groups endpoint" do
     let(:request_url) { api_url("groups") }
 
@@ -398,9 +394,9 @@ describe "opscode-account groups", :groups do
 
     context "DELETE /groups" do
       context "admin user" do
-        it "returns #{ruby? ? 404 : 405}" do
+        it "returns 405" do
           delete(request_url, platform.admin_user).should look_like({
-              :status => ruby? ? 404 : 405
+              :status => 405
             })
         end
       end
@@ -408,9 +404,9 @@ describe "opscode-account groups", :groups do
 
     context "PUT /groups" do
       context "admin user" do
-        it "returns #{ruby? ? 404 : 405}" do
+        it "returns 405" do
           put(request_url, platform.admin_user).should look_like({
-              :status => ruby? ? 404 : 405
+              :status => 405
             })
         end
       end
@@ -1154,9 +1150,9 @@ describe "opscode-account groups", :groups do
 
     context "POST /groups/<name>" do
       context "admin user" do
-        it "returns #{ruby? ? 404 : 405}" do
+        it "returns 405" do
           post(request_url, platform.admin_user).should look_like({
-              :status => ruby? ? 404 : 405
+              :status => 405
             })
         end
       end

--- a/spec/api/authenticate_user_spec.rb
+++ b/spec/api/authenticate_user_spec.rb
@@ -3,14 +3,6 @@ require 'pedant/rspec/common'
 require 'json'
 
 describe 'authenticate_user', :users do
-  def self.ruby?
-    Pedant::Config.ruby_users_endpoint?
-  end
-
-  def invalid_verb_response_code
-    ruby? ? 404 : 405
-  end
-
   let(:username) {
     if platform.ldap_testing
       platform.ldap[:account_name]
@@ -69,40 +61,34 @@ describe 'authenticate_user', :users do
         'email' => platform.non_admin_user.name + "@opscode.com",
         'username' => platform.non_admin_user.name
       }} }
-  let(:authentication_error_msg) {
-    if ruby?
-      "Failed to authenticate: Username and password incorrect"
-    else
-      ["Failed to authenticate: Username and password incorrect"]
-    end
-  }
+  let(:authentication_error_msg) { ["Failed to authenticate: Username and password incorrect"] }
 
   context 'GET /authenticate_user' do
 
     # We'd just loop this, but unfortunately, superuser et al aren't available outside
     # of test scope, so easier just to do multiple similar tests
 
-    it 'returns 404 ("Not Found") for superuser' do
+    it 'returns 405 for superuser' do
       get(request_url, superuser).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 
-    it 'returns 404 ("Not Found") for admin/different user' do
+    it 'returns 405 for admin/different user' do
       get(request_url, platform.admin_user).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 
-    it 'returns 404 ("Not Found") for non-admin/same user' do
+    it 'returns 405 for non-admin/same user' do
       get(request_url, platform.non_admin_user).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 
-    it 'returns 404 ("Not Found") for invalid user' do
+    it 'returns 405 for invalid user' do
       get(request_url, invalid_user).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 
@@ -110,25 +96,25 @@ describe 'authenticate_user', :users do
 
   context 'PUT /authenticate_user' do
 
-    it 'returns 404 ("Not Found") for superuser' do
+    it 'returns 405 for superuser' do
       put(request_url, superuser, :payload => body).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 
-    it 'returns 404 ("Not Found") for admin/different user' do
+    it 'returns 405 for admin/different user' do
       put(request_url, platform.admin_user, :payload => body).should look_like({
           :status => invalid_verb_response_code
         })
     end
 
-    it 'returns 404 ("Not Found") for non-admin/same user' do
+    it 'returns 405 for non-admin/same user' do
       put(request_url, platform.non_admin_user, :payload => body).should look_like({
           :status => invalid_verb_response_code
         })
     end
 
-    it 'returns 404 ("Not Found") for invalid user' do
+    it 'returns 405 for invalid user' do
       put(request_url, invalid_user, :payload => body).should look_like({
           :status => invalid_verb_response_code
         })
@@ -456,9 +442,9 @@ describe 'authenticate_user', :users do
           })
       end
 
-      it 'invalid user returns 401 ("Unauthorized") (ruby) or 400 ("Bad Request") (erlang)', :authentication, :validation do
+      it 'invalid user returns  400 ("Bad Request")', :validation do
         post(request_url, invalid_user).should look_like({
-            :status => ruby? ? 401 : 400
+            :status => 400
           })
       end
     end
@@ -509,11 +495,6 @@ describe 'authenticate_user', :users do
       end
 
       it "should return Forbidden", :authorization do
-
-        # Under ruby we should expect:
-        #     "error" => "Password authentication as the superuser is prohibited."
-        # But the oc_chef_wm_base framework doesn't support customized error messages
-        # when a 403 occurs during forbidden check.
         post(request_url, superuser, :payload => request_body).should look_like(
           :status => 403
         )
@@ -524,27 +505,27 @@ describe 'authenticate_user', :users do
   context 'DELETE /authenticate_user' do
     # This should do nothing0
 
-    it 'returns 404 ("Not Found") for superuser' do
+    it 'returns 405 for superuser' do
       delete(request_url, superuser).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 
-    it 'returns 404 ("Not Found") for admin/different user' do
+    it 'returns 405 for admin/different user' do
       delete(request_url, platform.admin_user).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 
-    it 'returns 404 ("Not Found") for non-admin/same user' do
+    it 'returns 405 for non-admin/same user' do
       delete(request_url, platform.non_admin_user).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 
-    it 'returns 404 ("Not Found") for invalid user' do
+    it 'returns 405 for invalid user' do
       delete(request_url, invalid_user).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 

--- a/spec/api/authenticate_user_spec.rb
+++ b/spec/api/authenticate_user_spec.rb
@@ -104,19 +104,19 @@ describe 'authenticate_user', :users do
 
     it 'returns 405 for admin/different user' do
       put(request_url, platform.admin_user, :payload => body).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 
     it 'returns 405 for non-admin/same user' do
       put(request_url, platform.non_admin_user, :payload => body).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 
     it 'returns 405 for invalid user' do
       put(request_url, invalid_user, :payload => body).should look_like({
-          :status => invalid_verb_response_code
+          :status => 405
         })
     end
 

--- a/spec/api/cookbooks/update_spec.rb
+++ b/spec/api/cookbooks/update_spec.rb
@@ -178,7 +178,7 @@ describe "Cookbooks API endpoint", :cookbooks, :cookbooks_update do
 
       end # it adding all new checksums should succeed
 
-      it "should return url when adding checksums (if ruby endpoint)" do
+      it "should return url when adding checksums" do
         payload = new_cookbook(cookbook_name, cookbook_version)
         payload["files"] = [{"name" => "name1", "path" => "path/name1",
                               "checksum" => checksums[0],
@@ -195,18 +195,19 @@ describe "Cookbooks API endpoint", :cookbooks, :cookbooks_update do
                                :body_exact => payload
                              })
         end
-
+        # TODO original description indicated ruby returned URI, and also b ody_exact was commented out below.
+        # Look into it ...
         # verify change happened
         # TODO make this match on body when URLs are parsable
         get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
             admin_user) do |response|
           response.
             should look_like({
-                               :status => 200
-                              # :body_exact => payload
+                               :status => 200,
+                               :body_exact => payload
                              })
         end
-      end # it should return url when adding checksums (if ruby endpoint)
+      end
 
       it "adding invalid checksum should fail", :validation do
         payload = new_cookbook(cookbook_name, cookbook_version)

--- a/spec/api/header_spec.rb
+++ b/spec/api/header_spec.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Author:: Douglas Triggs (<doug@getchef.com>)
-# Copyright:: Copyright (c) 2014 Chef, Inc.
+# Author:: Douglas Triggs (<doug@chef.io>)
+# Copyright:: Copyright (c) 2014-2015 Chef, Inc.
 
 describe "Headers", :headers do
   let (:request_url) { api_url("users") }
@@ -17,7 +17,7 @@ describe "Headers", :headers do
     let (:high_version_headers) { {"X-Chef-Version" => "999.0.0" } }
     let (:low_version_headers) { {"X-Chef-Version" => "9.0.1" } }
 
-    it "Accepts High Version", :pending => !Pedant::Config.chef_12? do
+    it "Accepts High Version" do
       #Pended until backport into 11
       get(request_url, requestor, :headers => high_version_headers).should look_like({
           :status => 200

--- a/spec/api/header_spec.rb
+++ b/spec/api/header_spec.rb
@@ -30,4 +30,20 @@ describe "Headers", :headers do
         })
     end
   end # context "Request Headers"
+  context "Response Headers" do
+    context "API v0", :api_v0 do
+      it "Should include an X-Ops-API-Info header" do
+        get(request_url, requestor).should look_like( status: 200,
+                                                     headers:  ["X-Ops-API-Info"])
+
+      end
+    end
+    context "API v1 Behavior", :api_v1 do
+      it "Should include an X-Ops-API-Info header" do
+        get(request_url, requestor).should look_like( status: 200,
+                                                     no_headers:  ["X-Ops-API-Info"])
+      end
+
+    end
+  end
 end # describe "Headers"

--- a/spec/api/license_spec.rb
+++ b/spec/api/license_spec.rb
@@ -22,108 +22,93 @@ describe 'license', :license do
       "upgrade_url" => /^http\:\/\.*/
     }}
 
-  if (Pedant::Config.chef_12?)
-    context "GET /license" do
-      context "with no nodes" do
+  context "GET /license" do
+    context "with no nodes" do
 
-        it "returns 200 and correct body for superuser" do
+      it "returns 200 and correct body for superuser" do
+        get(request_url, superuser).should look_like(
+          :body_exact => response_body,
+          :status => 200
+          )
+      end
+
+      it "returns 200 and correct body for admin user" do
+        get(request_url, platform.admin_user).should look_like(
+          :body_exact => response_body,
+          :status => 200
+          )
+      end
+
+      it "returns 200 and correct body for normal user" do
+        get(request_url, platform.non_admin_user).should look_like(
+          :body_exact => response_body,
+          :status => 200
+          )
+      end
+
+      it "returns 401 for invalid user", :authentication do
+        get(request_url, invalid_user).should look_like(
+          :status => 401
+          )
+      end
+
+      it "returns 401 for client", :authentication do
+        get(request_url, platform.non_admin_client).should look_like(
+          :status => 401
+          )
+      end
+
+    end # with no nodes
+
+    context "with nodes" do
+      let(:nodes) do
+        (1..node_count).map{|i| new_node(unique_name("pedant_node_list_test_#{i}"))}
+      end
+
+      before :each do
+        nodes.each do |n|
+          add_node(platform.admin_user, n)
+        end
+      end
+
+      after :each do
+        nodes.each do |n|
+          delete_node(platform.admin_user, n['name']).should look_like ({:response_code => 200})
+        end
+      end
+
+      context "with one node" do
+        let(:node_count) { 1 }
+
+        it "should return correct body for license status" do
           get(request_url, superuser).should look_like(
             :body_exact => response_body,
             :status => 200
             )
         end
+      end # with one node
 
-        it "returns 200 and correct body for admin user" do
-          get(request_url, platform.admin_user).should look_like(
+      context "with #{MAX_NODE_COUNT} nodes (license not exceeded)" do
+        let(:node_count) { MAX_NODE_COUNT }
+
+        it "should return correct body for license status" do
+          get(request_url, superuser).should look_like(
             :body_exact => response_body,
             :status => 200
             )
         end
-
-        it "returns 200 and correct body for normal user" do
-          get(request_url, platform.non_admin_user).should look_like(
-            :body_exact => response_body,
-            :status => 200
-            )
-        end
-
-        it "returns 401 for invalid user", :authentication do
-          get(request_url, invalid_user).should look_like(
-            :status => 401
-            )
-        end
-
-        it "returns 401 for client", :authentication do
-          get(request_url, platform.non_admin_client).should look_like(
-            :status => 401
-            )
-        end
-
-      end # with no nodes
-
-      context "with nodes" do
-        let(:nodes) do
-          (1..node_count).map{|i| new_node(unique_name("pedant_node_list_test_#{i}"))}
-        end
-
-        before :each do
-          nodes.each do |n|
-            add_node(platform.admin_user, n)
-          end
-        end
-
-        after :each do
-          nodes.each do |n|
-            delete_node(platform.admin_user, n['name']).should look_like ({:response_code => 200})
-          end
-        end
-
-        context "with one node" do
-          let(:node_count) { 1 }
-
-          it "should return correct body for license status" do
-            get(request_url, superuser).should look_like(
-              :body_exact => response_body,
-              :status => 200
-              )
-          end
-        end # with one node
-
-        context "with #{MAX_NODE_COUNT} nodes (license not exceeded)" do
-          let(:node_count) { MAX_NODE_COUNT }
-
-          it "should return correct body for license status" do
-            get(request_url, superuser).should look_like(
-              :body_exact => response_body,
-              :status => 200
-              )
-          end
-        end
-
-        context "with  #{MAX_NODE_COUNT + 1} (license exceeded)" do
-          let(:node_count) { MAX_NODE_COUNT + 1}
-          it "should return correct body for license status" do
-            get(request_url, superuser).should look_like(
-              :body_exact => response_body,
-              :status => 200
-              )
-          end
-        end # with thirty nodes
-      end # with nodes
-    end # GET /license
-
-  else
-
-    # This is a sanity check to make sure that the pedant configuration correctly
-    # turns on this spec with the license? setting when the license endpoint is
-    # present
-
-    context "verify no license endpoint" do
-      it "returns 404" do
-        get(request_url, superuser).should look_like(
-          :status => 404
-          )
       end
-    end
-  end
+
+      context "with  #{MAX_NODE_COUNT + 1} (license exceeded)" do
+        let(:node_count) { MAX_NODE_COUNT + 1}
+        it "should return correct body for license status" do
+          get(request_url, superuser).should look_like(
+            :body_exact => response_body,
+            :status => 200
+            )
+        end
+      end # with thirty nodes
+    end # with nodes
+  end # GET /license
+
 end # license

--- a/spec/api/policies/complete_endpoint_spec.rb
+++ b/spec/api/policies/complete_endpoint_spec.rb
@@ -98,217 +98,245 @@ describe "Policies API endpoint", :policies do
   end
 
   let(:request_payload) { raise "define payload" }
-  if (Pedant::Config.policies?)
-    context "when no policies exist on the server" do
+  context "when no policies exist on the server" do
 
-      context "GET" do
+    context "GET" do
 
-        let(:request_payload) { nil }
+      let(:request_payload) { nil }
 
-        let(:request_method) { :GET }
+      let(:request_method) { :GET }
 
-        it "GET /policies/:group/:name returns 404" do
-          expect(response.code).to eq(404)
+      it "GET /policies/:group/:name returns 404" do
+        expect(response.code).to eq(404)
+      end
+
+    end
+
+    context "DELETE" do
+
+      let(:request_payload) { nil }
+
+      let(:request_method) { :DELETE }
+
+      it "DELETE /policies/:group/:name returns 404" do
+        expect(response.code).to eq(404)
+      end
+
+    end
+
+    context "PUT" do
+
+      let(:request_method) { :PUT }
+
+      after(:each) do
+        delete(static_named_policy_url, requestor)
+      end
+
+      context "with a canonical payload" do
+
+        let(:request_payload) { canonical_policy_payload }
+
+        it "PUT /policies/:group/:name returns 201" do
+          expect(response.code).to eq(201)
+        end
+
+
+      end
+
+      context "with a minimal payload" do
+
+        let(:request_payload) { minimum_valid_policy_payload }
+
+        it "PUT /policies/:group/:name returns 201" do
+          expect(response.code).to eq(201)
         end
 
       end
 
-      context "DELETE" do
+      context "with a payload demonstrating validation edge conditions for 'name'" do
 
-        let(:request_payload) { nil }
+        context "when the name contains every valid character" do
+          let(:name_with_all_valid_chars) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }
 
-        let(:request_method) { :DELETE }
+          # Have to override the URL or else we will hit validation that name in
+          # document matches the one in URL
+          let(:static_named_policy_url) { api_url("/policy_groups/some_policy_group/policies/#{name_with_all_valid_chars}") }
 
-        it "DELETE /policies/:group/:name returns 404" do
-          expect(response.code).to eq(404)
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p["name"] = name_with_all_valid_chars }
+          end
+
+          it "PUT /policies/:group/:name returns 201" do
+            expect(response.code).to eq(201)
+          end
         end
 
+        context "when the name is close to the maximum size" do
+
+          # On Chef Zero, some backends will append `.json` to a file name,
+          # which can exceed the common limit of 255 characters.
+          let(:max_size_name) { 'a' * 250 }
+
+          # Have to override the URL or else we will hit validation that name in
+          # document matches the one in URL
+          let(:static_named_policy_url) { api_url("/policy_groups/some_policy_group/policies/#{max_size_name}") }
+
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p["name"] = max_size_name }
+          end
+
+          it "PUT /policies/:group/:name returns 201" do
+            expect(response.code).to eq(201)
+          end
+        end
+
+        context "when a revision_id is the maximum size" do
+
+          let(:max_size_revision_id) { 'a' * 255 }
+
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) do |policy|
+              policy["revision_id"] = max_size_revision_id
+            end
+          end
+
+          it "PUT /policies/:group/:name returns 201" do
+            expect(response.code).to eq(201)
+          end
+        end
+
+        context "when a revision_id contains every valid character" do
+
+          let(:revision_id_with_all_valid_chars) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }
+
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) do |policy|
+              policy["revision_id"] = revision_id_with_all_valid_chars
+            end
+          end
+
+
+          it "PUT /policies/:group/:name returns 201" do
+            expect(response.code).to eq(201)
+          end
+        end
+
+        context "when a cookbook identifier is the maximum size" do
+
+          let(:max_size_identifier) { 'a' * 255 }
+
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) do |policy|
+              policy["cookbook_locks"]["edge_case"] = {
+                "identifier" => max_size_identifier,
+                "version" => "1.2.3"
+              }
+            end
+          end
+
+          it "PUT /policies/:group/:name returns 201" do
+            expect(response.code).to eq(201)
+          end
+        end
+
+        context "when a cookbook identifier contains every valid character" do
+
+          let(:identifier_with_all_valid_chars) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }
+
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) do |policy|
+              policy["cookbook_locks"]["edge_case"] = {
+                "identifier" => identifier_with_all_valid_chars,
+                "version" => "1.2.3"
+              }
+            end
+          end
+
+          it "PUT /policies/:group/:name returns 201" do
+            expect(response.code).to eq(201)
+          end
+        end
       end
 
-      context "PUT" do
+      context "when the request body is invalid" do
 
-        let(:request_method) { :PUT }
+        shared_examples_for "an invalid policy document" do
 
-        after(:each) do
-          delete(static_named_policy_url, requestor)
-        end
-
-        context "with a canonical payload" do
-
-          let(:request_payload) { canonical_policy_payload }
-
-          it "PUT /policies/:group/:name returns 201" do
-            expect(response.code).to eq(201)
+          let(:error_message) do
+            response_obj = parse(response.body)
+            expect(response_obj).to be_a_kind_of(Hash)
+            expect(response_obj).to have_key("error")
+            expect(response_obj["error"]).to be_a_kind_of(Array)
+            expect(response_obj["error"].size).to eq(1)
+            response_obj["error"].first
           end
 
+          it "PUT /policies/:group/:name returns 400" do
+            expect(response.code).to eq(400)
+          end
 
-        end
-
-        context "with a minimal payload" do
-
-          let(:request_payload) { minimum_valid_policy_payload }
-
-          it "PUT /policies/:group/:name returns 201" do
-            expect(response.code).to eq(201)
+          it "PUT /policies/:group/:name body contains a well-formed error message" do
+            expect(error_message).to eq(expected_error_message)
           end
 
         end
 
-        context "with a payload demonstrating validation edge conditions for 'name'" do
+        ## MANDATORY FIELDS AND FORMATS
+        # * `revision_id`: String; Must be < 255 chars, matches /^[\-[:alnum:]_\.\:]+$/
+        # * `name`: String; Must match name in URI; Must be < 255 chars, matches /^[\-[:alnum:]_\.\:]+$/
+        # * `run_list`: Array
+        # * `run_list[i]`: Fully Qualified Recipe Run List Item
+        # * `cookbook_locks`: JSON Object
+        # * `cookbook_locks(key)`: CookbookName
+        # * `cookbook_locks[item]`: JSON Object, mandatory keys: "identifier", "dotted_decimal_identifier"
+        # * `cookbook_locks[item]["identifier"]`: varchar(255) ?
+        # * `cookbook_locks[item]["dotted_decimal_identifier"]` ChefCompatibleVersionNumber
 
-          context "when the name contains every valid character" do
-            let(:name_with_all_valid_chars) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }
+        context "because of missing revision id field" do
 
-            # Have to override the URL or else we will hit validation that name in
-            # document matches the one in URL
-            let(:static_named_policy_url) { api_url("/policy_groups/some_policy_group/policies/#{name_with_all_valid_chars}") }
-
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p["name"] = name_with_all_valid_chars }
-            end
-
-            it "PUT /policies/:group/:name returns 201" do
-              expect(response.code).to eq(201)
-            end
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p.delete("revision_id") }
           end
 
-          context "when the name is close to the maximum size" do
+          let(:expected_error_message) { "Field 'revision_id' missing" }
 
-            # On Chef Zero, some backends will append `.json` to a file name,
-            # which can exceed the common limit of 255 characters.
-            let(:max_size_name) { 'a' * 250 }
+          include_examples "an invalid policy document"
 
-            # Have to override the URL or else we will hit validation that name in
-            # document matches the one in URL
-            let(:static_named_policy_url) { api_url("/policy_groups/some_policy_group/policies/#{max_size_name}") }
-
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p["name"] = max_size_name }
-            end
-
-            it "PUT /policies/:group/:name returns 201" do
-              expect(response.code).to eq(201)
-            end
-          end
-
-          context "when a revision_id is the maximum size" do
-
-            let(:max_size_revision_id) { 'a' * 255 }
-
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) do |policy|
-                policy["revision_id"] = max_size_revision_id
-              end
-            end
-
-            it "PUT /policies/:group/:name returns 201" do
-              expect(response.code).to eq(201)
-            end
-          end
-
-          context "when a revision_id contains every valid character" do
-
-            let(:revision_id_with_all_valid_chars) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }
-
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) do |policy|
-                policy["revision_id"] = revision_id_with_all_valid_chars
-              end
-            end
-
-
-            it "PUT /policies/:group/:name returns 201" do
-              expect(response.code).to eq(201)
-            end
-          end
-
-          context "when a cookbook identifier is the maximum size" do
-
-            let(:max_size_identifier) { 'a' * 255 }
-
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) do |policy|
-                policy["cookbook_locks"]["edge_case"] = {
-                  "identifier" => max_size_identifier,
-                  "version" => "1.2.3"
-                }
-              end
-            end
-
-            it "PUT /policies/:group/:name returns 201" do
-              expect(response.code).to eq(201)
-            end
-          end
-
-          context "when a cookbook identifier contains every valid character" do
-
-            let(:identifier_with_all_valid_chars) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }
-
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) do |policy|
-                policy["cookbook_locks"]["edge_case"] = {
-                  "identifier" => identifier_with_all_valid_chars,
-                  "version" => "1.2.3"
-                }
-              end
-            end
-
-            it "PUT /policies/:group/:name returns 201" do
-              expect(response.code).to eq(201)
-            end
-          end
         end
 
-        context "when the request body is invalid" do
+        context "because revision id field is an empty string" do
 
-          shared_examples_for "an invalid policy document" do
-
-            let(:error_message) do
-              response_obj = parse(response.body)
-              expect(response_obj).to be_a_kind_of(Hash)
-              expect(response_obj).to have_key("error")
-              expect(response_obj["error"]).to be_a_kind_of(Array)
-              expect(response_obj["error"].size).to eq(1)
-              response_obj["error"].first
-            end
-
-            it "PUT /policies/:group/:name returns 400" do
-              expect(response.code).to eq(400)
-            end
-
-            it "PUT /policies/:group/:name body contains a well-formed error message" do
-              expect(error_message).to eq(expected_error_message)
-            end
-
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p["revision_id"] = "" }
           end
 
-          ## MANDATORY FIELDS AND FORMATS
-          # * `revision_id`: String; Must be < 255 chars, matches /^[\-[:alnum:]_\.\:]+$/
-          # * `name`: String; Must match name in URI; Must be < 255 chars, matches /^[\-[:alnum:]_\.\:]+$/
-          # * `run_list`: Array
-          # * `run_list[i]`: Fully Qualified Recipe Run List Item
-          # * `cookbook_locks`: JSON Object
-          # * `cookbook_locks(key)`: CookbookName
-          # * `cookbook_locks[item]`: JSON Object, mandatory keys: "identifier", "dotted_decimal_identifier"
-          # * `cookbook_locks[item]["identifier"]`: varchar(255) ?
-          # * `cookbook_locks[item]["dotted_decimal_identifier"]` ChefCompatibleVersionNumber
+          let(:expected_error_message) { "Field 'revision_id' invalid" }
 
-          context "because of missing revision id field" do
+          include_examples "an invalid policy document"
 
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p.delete("revision_id") }
-            end
+        end
 
-            let(:expected_error_message) { "Field 'revision_id' missing" }
+        context "because revision id field is larger than 255 characters" do
 
-            include_examples "an invalid policy document"
+          let(:long_revision_id_is_long) { "f" * 256 }
 
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p["revision_id"] = long_revision_id_is_long }
           end
 
-          context "because revision id field is an empty string" do
+          let(:expected_error_message) { "Field 'revision_id' invalid" }
+
+          include_examples "an invalid policy document"
+
+        end
+
+        [ ' ', '+', '!' ].each do |invalid_char|
+          context "because the revision_id contains invalid character #{invalid_char}" do
+
+            let(:invalid_revision_id) { "invalid" + invalid_char + "invalid" }
 
             let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p["revision_id"] = "" }
+              mutate_json(minimum_valid_policy_payload) { |p| p["revision_id"] = invalid_revision_id }
             end
 
             let(:expected_error_message) { "Field 'revision_id' invalid" }
@@ -316,72 +344,64 @@ describe "Policies API endpoint", :policies do
             include_examples "an invalid policy document"
 
           end
+        end
 
-          context "because revision id field is larger than 255 characters" do
 
-            let(:long_revision_id_is_long) { "f" * 256 }
+        context "because of missing name field" do
 
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p["revision_id"] = long_revision_id_is_long }
-            end
-
-            let(:expected_error_message) { "Field 'revision_id' invalid" }
-
-            include_examples "an invalid policy document"
-
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p.delete("name") }
           end
 
-          [ ' ', '+', '!' ].each do |invalid_char|
-            context "because the revision_id contains invalid character #{invalid_char}" do
+          let(:expected_error_message) { "Field 'name' missing" }
 
-              let(:invalid_revision_id) { "invalid" + invalid_char + "invalid" }
+          include_examples "an invalid policy document"
 
-              let(:request_payload) do
-                mutate_json(minimum_valid_policy_payload) { |p| p["revision_id"] = invalid_revision_id }
-              end
+        end
 
-              let(:expected_error_message) { "Field 'revision_id' invalid" }
+        context "because of an mismatched name field" do
 
-              include_examples "an invalid policy document"
-
-            end
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p["name"] = "monkeypants" }
           end
 
+          let(:expected_error_message) { "Field 'name' invalid : some_policy_name does not match monkeypants" }
 
-          context "because of missing name field" do
+          include_examples "an invalid policy document"
 
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p.delete("name") }
-            end
+        end
 
-            let(:expected_error_message) { "Field 'name' missing" }
+        context "because the name is larger than 255 characters" do
 
-            include_examples "an invalid policy document"
+          let(:long_name_is_long) { "z" * 256 }
 
+          # Have to override the URL or else we might only hit validation that
+          # name in document matches the one in URL
+          let(:static_named_policy_url) { api_url("/policy_groups/some_policy_group/policies/#{long_name_is_long}") }
+
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p["name"] = long_name_is_long }
           end
 
-          context "because of an mismatched name field" do
+          let(:expected_error_message) { "Field 'name' invalid" }
 
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p["name"] = "monkeypants" }
-            end
+          include_examples "an invalid policy document"
 
-            let(:expected_error_message) { "Field 'name' invalid : some_policy_name does not match monkeypants" }
+        end
 
-            include_examples "an invalid policy document"
+        [ ' ', '+', '!' ].each do |invalid_char|
+          context "because the name contains invalid character '#{invalid_char}'" do
 
-          end
+            let(:invalid_policy_name) { "invalid" + invalid_char + "invalid" }
 
-          context "because the name is larger than 255 characters" do
-
-            let(:long_name_is_long) { "z" * 256 }
+            let(:encoded_invalid_name) { URI.encode(invalid_policy_name) }
 
             # Have to override the URL or else we might only hit validation that
             # name in document matches the one in URL
-            let(:static_named_policy_url) { api_url("/policy_groups/some_policy_group/policies/#{long_name_is_long}") }
+            let(:static_named_policy_url) { api_url("/policy_groups/some_policy_group/policies/#{encoded_invalid_name}") }
 
             let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p["name"] = long_name_is_long }
+              mutate_json(minimum_valid_policy_payload) { |p| p["name"] = invalid_policy_name }
             end
 
             let(:expected_error_message) { "Field 'name' invalid" }
@@ -389,45 +409,40 @@ describe "Policies API endpoint", :policies do
             include_examples "an invalid policy document"
 
           end
+        end
 
-          [ ' ', '+', '!' ].each do |invalid_char|
-            context "because the name contains invalid character '#{invalid_char}'" do
+        context "because of missing run_list field" do
 
-              let(:invalid_policy_name) { "invalid" + invalid_char + "invalid" }
-
-              let(:encoded_invalid_name) { URI.encode(invalid_policy_name) }
-
-              # Have to override the URL or else we might only hit validation that
-              # name in document matches the one in URL
-              let(:static_named_policy_url) { api_url("/policy_groups/some_policy_group/policies/#{encoded_invalid_name}") }
-
-              let(:request_payload) do
-                mutate_json(minimum_valid_policy_payload) { |p| p["name"] = invalid_policy_name }
-              end
-
-              let(:expected_error_message) { "Field 'name' invalid" }
-
-              include_examples "an invalid policy document"
-
-            end
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p.delete("run_list") }
           end
 
-          context "because of missing run_list field" do
+          let(:expected_error_message) { "Field 'run_list' missing" }
 
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p.delete("run_list") }
-            end
+          include_examples "an invalid policy document"
 
-            let(:expected_error_message) { "Field 'run_list' missing" }
+        end
 
-            include_examples "an invalid policy document"
+        context "because run_list field is the wrong type" do
 
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p["run_list"] = {} }
           end
 
-          context "because run_list field is the wrong type" do
+          let(:expected_error_message) { "Field 'run_list' is not a valid run list" }
+
+          include_examples "an invalid policy document"
+
+        end
+
+        # Run list items in policies are required to be fully normalized recipe names, e.g,
+        # "recipe[mysql::default]"
+        [123, "recipe[", "role[foo]", "recipe[foo]"].each do |invalid_run_list_item|
+
+          context "because the run_list has invalid item '#{invalid_run_list_item}'" do
 
             let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p["run_list"] = {} }
+              mutate_json(minimum_valid_policy_payload) { |p| p["run_list"] = [ invalid_run_list_item ] }
             end
 
             let(:expected_error_message) { "Field 'run_list' is not a valid run list" }
@@ -436,116 +451,98 @@ describe "Policies API endpoint", :policies do
 
           end
 
-          # Run list items in policies are required to be fully normalized recipe names, e.g,
-          # "recipe[mysql::default]"
-          [123, "recipe[", "role[foo]", "recipe[foo]"].each do |invalid_run_list_item|
+        end
 
-            context "because the run_list has invalid item '#{invalid_run_list_item}'" do
+        context "because cookbook_locks field is missing" do
 
-              let(:request_payload) do
-                mutate_json(minimum_valid_policy_payload) { |p| p["run_list"] = [ invalid_run_list_item ] }
-              end
-
-              let(:expected_error_message) { "Field 'run_list' is not a valid run list" }
-
-              include_examples "an invalid policy document"
-
-            end
-
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p.delete("cookbook_locks") }
           end
 
-          context "because cookbook_locks field is missing" do
+          let(:expected_error_message) { "Field 'cookbook_locks' missing" }
 
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p.delete("cookbook_locks") }
-            end
+          include_examples "an invalid policy document"
 
-            let(:expected_error_message) { "Field 'cookbook_locks' missing" }
+        end
 
-            include_examples "an invalid policy document"
+        context "because cookbook_locks field is the wrong type" do
 
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p["cookbook_locks"] = [] }
           end
 
-          context "because cookbook_locks field is the wrong type" do
+          let(:expected_error_message) { "Field 'cookbook_locks' invalid" }
 
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p["cookbook_locks"] = [] }
-            end
+          include_examples "an invalid policy document"
 
-            let(:expected_error_message) { "Field 'cookbook_locks' invalid" }
+        end
 
-            include_examples "an invalid policy document"
+        context "because cookbook_locks contains an entry of the wrong type" do
 
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) { |p| p["cookbook_locks"]["invalid_member"] = [] }
           end
 
-          context "because cookbook_locks contains an entry of the wrong type" do
+          let(:expected_error_message) { "Field 'cookbook_locks' invalid" }
 
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) { |p| p["cookbook_locks"]["invalid_member"] = [] }
-            end
+          # TODO: customizing the 400 message for this is currently difficult
+          # in erchef, so we skip validating the message.
 
-            let(:expected_error_message) { "Field 'cookbook_locks' invalid" }
-
-            # TODO: customizing the 400 message for this is currently difficult
-            # in erchef, so we skip validating the message.
-
-            it "PUT /policies/:group/:name returns 400" do
-              expect(response.code).to eq(400)
-            end
-
+          it "PUT /policies/:group/:name returns 400" do
+            expect(response.code).to eq(400)
           end
 
-          context "because cookbook_locks contains an entry that is missing the identifier field" do
+        end
 
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) do |policy|
-                policy["cookbook_locks"]["invalid_member"] = { "dotted_decimal_identifier" => "1.2.3" }
-              end
+        context "because cookbook_locks contains an entry that is missing the identifier field" do
+
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) do |policy|
+              policy["cookbook_locks"]["invalid_member"] = { "dotted_decimal_identifier" => "1.2.3" }
             end
-
-            let(:expected_error_message) { "Field 'identifier' missing" }
-
-            include_examples "an invalid policy document"
-
           end
 
-          context "because cookbook_locks contains an entry with an identifier larger than 255 characters" do
+          let(:expected_error_message) { "Field 'identifier' missing" }
 
-            let(:long_identifier) { "a" * 256 }
+          include_examples "an invalid policy document"
 
-            let(:invalid_lock) do
-              {
-                "identifier" => long_identifier,
-                "version" => "1.2.3"
-              }
-            end
+        end
 
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) do |policy|
-                policy["cookbook_locks"]["invalid_member"] = invalid_lock
-              end
-            end
+        context "because cookbook_locks contains an entry with an identifier larger than 255 characters" do
 
-            let(:expected_error_message) { "Field 'identifier' invalid" }
+          let(:long_identifier) { "a" * 256 }
 
-            include_examples "an invalid policy document"
-
+          let(:invalid_lock) do
+            {
+              "identifier" => long_identifier,
+              "version" => "1.2.3"
+            }
           end
 
-
-          context "because cookbook_locks contains an entry with an invalid dotted_decimal_identifier field" do
-
-            let(:request_payload) do
-              mutate_json(minimum_valid_policy_payload) do |policy|
-                policy["cookbook_locks"]["invalid_member"] = { "identifier" => "123def", "version" => "1.2.3", "dotted_decimal_identifier" => "foo" }
-              end
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) do |policy|
+              policy["cookbook_locks"]["invalid_member"] = invalid_lock
             end
-
-            let(:expected_error_message) { "Field 'dotted_decimal_identifier' is not a valid version" }
-
-            include_examples "an invalid policy document"
-
           end
+
+          let(:expected_error_message) { "Field 'identifier' invalid" }
+
+          include_examples "an invalid policy document"
+
+        end
+
+
+        context "because cookbook_locks contains an entry with an invalid dotted_decimal_identifier field" do
+
+          let(:request_payload) do
+            mutate_json(minimum_valid_policy_payload) do |policy|
+              policy["cookbook_locks"]["invalid_member"] = { "identifier" => "123def", "version" => "1.2.3", "dotted_decimal_identifier" => "foo" }
+            end
+          end
+
+          let(:expected_error_message) { "Field 'dotted_decimal_identifier' is not a valid version" }
+
+          include_examples "an invalid policy document"
 
         end
 
@@ -553,96 +550,84 @@ describe "Policies API endpoint", :policies do
 
     end
 
-    context "when a policy exists on the server" do
+  end
+
+  context "when a policy exists on the server" do
+
+    before(:each) do
+      put(static_named_policy_url, requestor, payload: canonical_policy_payload)
+    end
+
+    context "GET" do
+
+      let(:request_method) { :GET }
+
+      let(:request_payload) { nil }
+
+      it "retrieves the policy document" do
+        expect(JSON.parse(response.body)).to eq(JSON.parse(canonical_policy_payload))
+      end
+
+    end
+
+    context "PUT (update policy document)" do
+
+      let(:updated_canonical_policy_payload) do
+        mutate_json(canonical_policy_payload) do |policy|
+          policy["revision_id"] = "d4991d020462724edcf05f572e1d856cc5927803"
+          policy["cookbook_locks"]["policyfile_demo"]["identifier"] = "2a42abea88dc847bf6d3194af8bf899908642421"
+          policy["cookbook_locks"]["policyfile_demo"]["dotted_decimal_identifier"] = "11895255163526276.34892808658286783.151290363782177"
+        end
+      end
+
+      let(:request_payload) { updated_canonical_policy_payload }
+
+      let(:request_method) { :PUT }
 
       before(:each) do
-        put(static_named_policy_url, requestor, payload: canonical_policy_payload)
+        # Force the update PUT to occur
+        response
       end
 
-      context "GET" do
-
-        let(:request_method) { :GET }
-
-        let(:request_payload) { nil }
-
-        it "retrieves the policy document" do
-          expect(JSON.parse(response.body)).to eq(JSON.parse(canonical_policy_payload))
-        end
-
+      it "PUT /policies/:group/:name returns 200" do
+        expect(response.code).to eq(200)
+        expect(response.body).to eq(updated_canonical_policy_payload)
       end
 
-      context "PUT (update policy document)" do
+      it "GET /policies/:group/:name subsequently returns the updated document" do
+        retrieved_doc = get(static_named_policy_url, requestor)
+        expect(retrieved_doc.code).to eq(200)
+        expect(retrieved_doc.body).to eq(updated_canonical_policy_payload)
+      end
+    end
 
-        let(:updated_canonical_policy_payload) do
-          mutate_json(canonical_policy_payload) do |policy|
-            policy["revision_id"] = "d4991d020462724edcf05f572e1d856cc5927803"
-            policy["cookbook_locks"]["policyfile_demo"]["identifier"] = "2a42abea88dc847bf6d3194af8bf899908642421"
-            policy["cookbook_locks"]["policyfile_demo"]["dotted_decimal_identifier"] = "11895255163526276.34892808658286783.151290363782177"
-          end
-        end
+    context "DELETE" do
 
-        let(:request_payload) { updated_canonical_policy_payload }
+      let(:request_payload) { nil }
 
-        let(:request_method) { :PUT }
+      let(:request_method) { :DELETE }
 
-        before(:each) do
-          # Force the update PUT to occur
-          response
-        end
-
-        it "PUT /policies/:group/:name returns 200" do
-          expect(response.code).to eq(200)
-          expect(response.body).to eq(updated_canonical_policy_payload)
-        end
-
-        it "GET /policies/:group/:name subsequently returns the updated document" do
-          retrieved_doc = get(static_named_policy_url, requestor)
-          expect(retrieved_doc.code).to eq(200)
-          expect(retrieved_doc.body).to eq(updated_canonical_policy_payload)
-        end
+      before(:each) do
+        # Force the DELETE to occur
+        response
       end
 
-      context "DELETE" do
 
-        let(:request_payload) { nil }
-
-        let(:request_method) { :DELETE }
-
-        before(:each) do
-          # Force the DELETE to occur
-          response
-        end
-
-
-        it "DELETE /policies/:group/:name returns the deleted document" do
-          expect(response.code).to eq(200)
-          expect(JSON.parse(response.body)).to eq(JSON.parse(canonical_policy_payload))
-        end
-
-        it "DELETE /policies/:group/:name removes the policy from the data store" do
-          subsequent_get = get(static_named_policy_url, requestor)
-          expect(subsequent_get.code).to eq(404)
-        end
-
-
+      it "DELETE /policies/:group/:name returns the deleted document" do
+        expect(response.code).to eq(200)
+        expect(JSON.parse(response.body)).to eq(JSON.parse(canonical_policy_payload))
       end
+
+      it "DELETE /policies/:group/:name removes the policy from the data store" do
+        subsequent_get = get(static_named_policy_url, requestor)
+        expect(subsequent_get.code).to eq(404)
+      end
+
 
     end
 
-  else
-
-    # This is a sanity check to make sure that the pedant configuration correctly
-    # turns on this spec with the license? setting when the license endpoint is
-    # present
-
-    context "verify no policy endpoint" do
-      it "returns 404" do
-        get(request_url, requestor).should look_like(
-          :status => 404
-        )
-      end
-    end
   end
+
 end
 
 

--- a/spec/api/system_recovery_spec.rb
+++ b/spec/api/system_recovery_spec.rb
@@ -20,10 +20,6 @@
 # that pedant is the wrong place to do such an infrastructure / service-interactive test.
 describe 'system_recovery', :users do
 
-  def self.ruby?
-    Pedant::Config.ruby_system_recovery_endpoint?
-  end
-
   let(:external_auth_id) {
     "#{Time.now.to_i}-#{Process.pid}"  }
 
@@ -89,15 +85,9 @@ describe 'system_recovery', :users do
           }
         }
 
-        if (ruby?)
-          let(:error_message) {
-            "Failed to authenticate: "
-          }
-        else
-          let(:error_message) {
-            ["Failed to authenticate: Username and password incorrect"]
-          }
-        end
+        let(:error_message) {
+          ["Failed to authenticate: Username and password incorrect"]
+        }
 
         it "should return 401 with an error message" do
           post(request_url, superuser, :payload => wrong_pw_user_body).should look_like(
@@ -109,15 +99,9 @@ describe 'system_recovery', :users do
 
       context "when a non-superuser is the requestor" do
 
-        if (ruby?)
-          let(:error_message) {
-            "#{username} not authorized for verify_password"
-          }
-        else
-          let(:error_message) {
-            ["missing create permission"]
-          }
-        end
+        let(:error_message) {
+          ["missing create permission"]
+        }
 
         # TODO: the error string from opscode-account returns
         # the user in the body and not the requestor user
@@ -154,15 +138,7 @@ describe 'system_recovery', :users do
         }
       }
 
-      if (ruby?)
-        let(:error_message) {
-          "User is not allowed to take this action"
-        }
-      else
-        let(:error_message) {
-          ["System recovery disabled for this user"]
-        }
-      end
+      let(:error_message) { ["System recovery disabled for this user"] }
 
       # create a new recovery_authentication_enabled:false user
       before :each do
@@ -195,41 +171,22 @@ describe 'system_recovery', :users do
         }
       }
 
-      if (ruby?)
-        let(:error_message) {
-          "User is not found in the system"
-        }
-      else
-        let(:error_message) {
-          ["System recovery disabled for this user"]
-        }
-      end
+      let(:error_message) { ["System recovery disabled for this user"] }
 
       it "should return 404 with an error message" do
         post(request_url, superuser, :payload => user_body).should look_like(
           :body => {
             "error" => error_message
           },
-          :status => ruby? ? 404 : 403
+          :status => 403
         )
       end # should return 404 with an error message
     end # when a user that does not exist is requested by the superuser
 
     context "when the request is missing the username field" do
 
-      let(:missing_username_body) {
-        { 'password' => "foobar" }
-      }
-
-      if (ruby?)
-        let(:error_body) {{
-            "error" => "username and password are required"
-          }}
-      else
-        let(:error_body) {{
-            "error" => ["Field 'username' missing"]
-          }}
-      end
+      let(:missing_username_body) { { 'password' => "foobar" } }
+      let(:error_body) {{ "error" => ["Field 'username' missing"] }}
 
       it "should return 400 with an error message", :validation do
         post(request_url, superuser, :payload => missing_username_body).should look_like(
@@ -245,15 +202,7 @@ describe 'system_recovery', :users do
         { "username" => username }
       }
 
-      if (ruby?)
-        let(:error_body) {{
-            "error" => "username and password are required"
-          }}
-      else
-        let(:error_body) {{
-            "error" => ["Field 'password' missing"]
-          }}
-      end
+      let(:error_body) {{ "error" => ["Field 'password' missing"] }}
 
       it "should return 400 with an error message", :validation do
         post(request_url, superuser, :payload => missing_username_body).should look_like(


### PR DESCRIPTION
This PR removes `ruby?` and `ruby_*?` checks throughout, since we have no ruby support in the current master version of erchef that this is linked to (and soon to be merged with). 

It also removes behaviors specific to pre-chef server 12, and leaves only chef 12 paths in place. 

ping @chef/lob 
