### PR TITLE
Import policies changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    oc-chef-pedant (2.0.0)
+    oc-chef-pedant (2.0.1)
       activesupport (~> 3.2.8)
       erubis (~> 2.7.0)
       mixlib-authentication (~> 1.3.0)
@@ -40,7 +40,7 @@ GEM
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
     mixlib-shellout (2.0.1)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     net-http-spy (0.2.1)
     netrc (0.7.9)
     rdoc (4.2.0)
@@ -49,7 +49,7 @@ GEM
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
       rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.1)
+    rspec-core (3.2.2)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.0)
       diff-lcs (>= 1.2.0, < 2.0)


### PR DESCRIPTION
These seem to have been skipped in the big pecan merge. Updates policy tests to include now-required `revision_id` field and 400 tests now match the policyfile HTTP API RFC (draft).