### PR TITLE
server api versioning

### DIFF
--- a/lib/pedant/command_line.rb
+++ b/lib/pedant/command_line.rb
@@ -17,7 +17,9 @@ require 'optparse'
 
 module Pedant
 
-  class CommandLine < Struct.new(:junit_file, :config_file, :log_file, :include_internal, :only_internal, :run_all, :exclude_internal_orgs, :only_internal_orgs, :verify_error_messages, :bell_on_completion, :rerun, :use_default_org, :ssl_version)
+  class CommandLine < Struct.new(:junit_file, :config_file, :log_file, :include_internal, :only_internal,
+                                 :run_all, :exclude_internal_orgs, :only_internal_orgs, :verify_error_messages,
+                                 :bell_on_completion, :rerun, :use_default_org, :ssl_version, :server_api_version)
 
     def initialize(argv)
       @argv = argv.dup
@@ -109,9 +111,11 @@ module Pedant
       opts.on("--rerun", "Run tests that failed the last time") do
         self.rerun = true
       end
-
       opts.on("--ssl-version VERSION", "Specify SSL version to use when connecting to an ssl-enabled endpoint. Defaults to TLSv1 if not specified") do |v|
         self.ssl_version = f.split(/ /).first.to_sym
+      end
+      opts.on("-V", "--server-api-version", "Set the Server API version") do |v|
+        self.server_api_version = v
       end
     end
 
@@ -121,13 +125,13 @@ module Pedant
       # --help does not actually sort these, so ordering is important.
       sorted.each do |tag|
         opts.on("--focus-#{tag}", "Run only #{tag} tests") do
-          self.foci << tag
+          self.foci << tag.gsub("-", "_") # allow hyphenated tags that resolve to symbols/tags with underscores
         end
       end
 
       sorted.each do |tag|
         opts.on("--skip-#{tag}", "Skip #{tag} tests") do
-          self.skip << tag
+          self.skip << tag.gsub("-", "_")
         end
       end
 
@@ -138,7 +142,7 @@ module Pedant
                 clients depsolver search knife validation authentication authorization
                 principals acl containers groups association omnibus organizations
                 usags internal_orgs rename_org controls keys cookbook_artifacts
-                license headers)
+                license headers server-api-version)
       export_options(opts, tags)
     end
 

--- a/lib/pedant/config.rb
+++ b/lib/pedant/config.rb
@@ -130,5 +130,10 @@ module Pedant
 
     # Default orgname is nil by default
     default_orgname(nil)
+
+    # Default API version is zero. Note that this value
+    # is expected to be updated when minimum supported
+    # API version of the server changes.
+    server_api_version(0)
   end
 end

--- a/lib/pedant/rspec/matchers.rb
+++ b/lib/pedant/rspec/matchers.rb
@@ -91,7 +91,24 @@ module RSpec
               # need to cut short the rest of the logic to provide a
               # better message
               return false if @actual.nil?
-              size_is_same = (spec.size == value.size)
+
+              # A note here - when we're handling a key of :hashwrapper this means that
+              # this was a top-level array handed in for comparison. In that case,
+              # we will drive exactness of array match based on the strict?
+              # setting, since if the caller wanted an exact match of the array elements
+              # they would use body_exact (strict? == true)
+              if (key == :hashwrapper)
+                if strict?
+                  size_is_same = (spec.size == value.size)
+                else
+                  size_is_same = true # don't compare sizes, only the required elements
+                end
+              else
+                # In this case this is just one field among many contained in a hash - existing
+                # behavior expects this to match exactly even if we're not strictly matching
+                size_is_same = (spec.size == value.size)
+              end
+
               all_items_included = spec.all? { |item| value.include?(item) }
               size_is_same && all_items_included
             end

--- a/lib/pedant/rspec/matchers.rb
+++ b/lib/pedant/rspec/matchers.rb
@@ -253,6 +253,7 @@ end
 # :headers => a map of header names and expected values.  Only tests
 #     the specified headers, and makes no assumptions about
 #     unspecified headers.
+# :no_headers => an array of header names that should NOT be present
 
 RSpec::Matchers.define :look_like do |expected_response_spec|
   include ::Pedant::JSON
@@ -274,12 +275,19 @@ RSpec::Matchers.define :look_like do |expected_response_spec|
         expect(response).to eq expected_response_spec[:body_raw]
       end
 
+      actual_headers = response.raw_headers
       # Test the headers
       if expected_response_spec[:headers]
         headers = expected_response_spec[:headers]
-        actual_headers = response.raw_headers
         headers.each do |header, value|
           actual_headers[header].should eq value
+        end
+      end
+
+      # Test headers that shouldn't be
+      if expected_response_spec[:no_headers]
+        expected_response_spec[:no_headers].each do |header|
+          actual_headers.key?(header).should be(false)
         end
       end
 

--- a/spec/api/server_api_version_spec.rb
+++ b/spec/api/server_api_version_spec.rb
@@ -1,0 +1,69 @@
+
+context "Server API Versioning", :server_api_version, :smoke do
+  it "GET /server_api_version should respond with valid current server api version data" do
+    r = get("#{platform.server}/server_api_version", superuser)
+    r.should look_like(status_for_json: 200)
+    data = JSON.parse(r)
+    data.has_key?("min_api_version").should eql true
+    data.has_key?("max_api_version").should eql true
+    data["min_api_version"].should be_a(Fixnum)
+    data["max_api_version"].should be_a(Fixnum)
+    expect(data["min_api_version"]).to be <= data["max_api_version"]
+  end
+
+  context "version validation should occur before most other validation" do
+    it "invalid method should fail for version, not method" do
+      # These are invalid operations for the endpoint in use, and would normally result in a 405
+      put("#{platform.server}/license", superuser, :payload => {}, :api_version => "invalid").should  have_status_code 406
+      post("#{platform.server}/license", superuser, :payload => {}, :api_version => "invalid").should have_status_code 406
+      delete("#{platform.server}/license", superuser, :api_version => "invalid").should have_status_code 406
+    end
+    it "invalid content should fail for version, not content" do
+      # This would ordinarily be a 400
+      post("#{platform.server}/users", superuser, :payload => {}, :api_version => "invalid").should have_status_code 406
+    end
+  end
+
+  context "any request should validate requested server api version" do
+    before(:all) do
+      r = get("#{platform.server}/server_api_version", superuser)
+      data = JSON.parse(r)
+      @min_version = data["min_api_version"]
+      @max_version = data["max_api_version"]
+    end
+
+    it "and it should reply with the error message as specified in the RFC" do
+      expected_body = { "error" => "invalid-x-ops-server-api-version", "message" => "Specified version invalid not supported",
+                        "min_version" => @min_version, "max_version" => @max_version}
+      get("#{platform.server}/license", superuser, :api_version => "invalid").should look_like(status: 406,
+                                                                                               body_exact: expected_body)
+    end
+    it "and rejects when version is not a number" do
+      get("#{platform.server}/license", superuser, :api_version => "invalid").should have_status_code 406
+
+    end
+    it "and rejects when version is higher than what's supported" do
+      get("#{platform.server}/license", superuser, :api_version => @max_version + 1).should have_status_code 406
+
+    end
+    it "and rejects when version is lower than what's supported" do
+      get("#{platform.server}/license", superuser, :api_version => @min_version - 1).should have_status_code 406
+    end
+    it "and accepts when version is exactly the minimum of what's supported" do
+
+      get("#{platform.server}/license", superuser, :api_version => @min_version).should have_status_code 200
+    end
+    it "and accepts when version is exactly the maximum of what's supported" do
+      get("#{platform.server}/license", superuser, :api_version => @min_version).should have_status_code 200
+    end
+
+    it "and accepts when it's in valid range of what's supported" do
+      # Note that until we rev api versiona gain, this is the same as exactly maximum...
+      get("#{platform.server}/license", superuser, :api_version => @min_version + 1).should have_status_code 200
+    end
+
+    it "and accept it when it's not specified" do
+      get("#{platform.server}/license", superuser, :api_version => nil).should have_status_code 200
+    end
+  end
+end


### PR DESCRIPTION
* tests for server API version compliance with RFC including new endpoint
* added support for 'friendly' hyphenated focus names. It's now possible to specify a focus with an underscore, eg "server_api_version", but specify the option name with hyphens, "server-api-version" and have it resolve correctly. 

