### PR TITLE
Enable policies by default in example config

### DIFF
--- a/pedant_config.rb
+++ b/pedant_config.rb
@@ -211,7 +211,7 @@ ruby_org_acl_endpoint?     false
 ruby_org_assoc?            false
 ruby_organizations_endpoint? false
 chef_12?                   true
-policies?                   false
+policies?                  true
 
 old_runlists_and_search true
 


### PR DESCRIPTION
Enable policies tests by default in the example config. Note that I'm working on actually enabling the APIs by default in an opcode-omnibus branch, though for the Chef Server packages we generate our own config so this shouldn't affect anything (and doesn't need to be released, it can ship whenever).

@chef/lob 